### PR TITLE
Fix error ClassCastException

### DIFF
--- a/v1_16_R3/src/main/java/com/bgsoftware/wildstacker/nms/NMSAdapter_v1_16_R3.java
+++ b/v1_16_R3/src/main/java/com/bgsoftware/wildstacker/nms/NMSAdapter_v1_16_R3.java
@@ -250,14 +250,18 @@ public final class NMSAdapter_v1_16_R3 implements NMSAdapter {
 
     @Override
     public void setNerfedEntity(LivingEntity livingEntity, boolean nerfed) {
-        EntityInsentient entityLiving = (EntityInsentient) ((CraftLivingEntity) livingEntity).getHandle();
-        try { entityLiving.aware = !nerfed; } catch(Throwable ignored){ }
+        try {
+            EntityInsentient entityLiving = (EntityInsentient) ((CraftLivingEntity) livingEntity).getHandle();
+            try { entityLiving.aware = !nerfed; } catch(Throwable ignored){ }
 
-        if(Fields.ENTITY_FROM_MOB_SPAWNER.exists())
-            Fields.ENTITY_FROM_MOB_SPAWNER.set(entityLiving, nerfed);
+            if(Fields.ENTITY_FROM_MOB_SPAWNER.exists())
+                Fields.ENTITY_FROM_MOB_SPAWNER.set(entityLiving, nerfed);
 
-        if(Fields.ENTITY_SPAWNED_VIA_MOB_SPAWNER.exists())
-            Fields.ENTITY_SPAWNED_VIA_MOB_SPAWNER.set(entityLiving, nerfed);
+            if(Fields.ENTITY_SPAWNED_VIA_MOB_SPAWNER.exists())
+                Fields.ENTITY_SPAWNED_VIA_MOB_SPAWNER.set(entityLiving, nerfed);   
+        } catch (ClassCastException ignored) {
+            
+        }
     }
 
     @Override


### PR DESCRIPTION
`[04:37:09 WARN]: java.lang.ClassCastException: class net.minecraft.server.v1_16_R3.EntityArmorStand cannot be cast to class net.minecraft.server.v1_16_R3.EntityInsentient (net.minecraft.server.v1_16_R3.EntityArmorStand and net.minecraft.server.v1_16_R3.EntityInsentient are in unnamed module of loader 'app')
[04:37:09 WARN]:        at com.bgsoftware.wildstacker.nms.NMSAdapter_v1_16_R3.setNerfedEntity(NMSAdapter_v1_16_R3.java:265)
[04:37:09 WARN]:        at com.bgsoftware.wildstacker.objects.WStackedEntity.setNerfed(WStackedEntity.java:671)
[04:37:09 WARN]:        at com.bgsoftware.wildstacker.objects.WStackedEntity.updateNerfed(WStackedEntity.java:676)
[04:37:09 WARN]:        at com.bgsoftware.wildstacker.handlers.SystemHandler.handleChunkLoad(SystemHandler.java:565)
[04:37:09 WARN]:        at com.bgsoftware.wildstacker.handlers.DataHandler.loadDatabase(DataHandler.java:252)
[04:37:09 WARN]:        at com.bgsoftware.wildstacker.handlers.DataHandler.lambda$new$1(DataHandler.java:69)
[04:37:09 WARN]:        at org.bukkit.craftbukkit.v1_16_R3.scheduler.CraftTask.run(CraftTask.java:99)
[04:37:09 WARN]:        at org.bukkit.craftbukkit.v1_16_R3.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:439)
[04:37:09 WARN]:        at net.minecraft.server.v1_16_R3.MinecraftServer.w(MinecraftServer.java:938)
[04:37:09 WARN]:        at net.minecraft.server.v1_16_R3.MinecraftServer.lambda$a$0(MinecraftServer.java:177)
[04:37:09 WARN]:        at java.base/java.lang.Thread.run(Thread.java:832)`