### PR TITLE
Fix fire and dupe issue on breed

### DIFF
--- a/NMS/v1_21_7/src/main/java/com/bgsoftware/wildstacker/nms/v1_21_7/NMSAdapterImpl.java
+++ b/NMS/v1_21_7/src/main/java/com/bgsoftware/wildstacker/nms/v1_21_7/NMSAdapterImpl.java
@@ -52,7 +52,7 @@ public final class NMSAdapterImpl implements NMSAdapter {
 
     private static final String[] ENTITY_NBT_TAGS_TO_REMOVE = new String[]{
             "SaddleItem", "Saddle", "ArmorItem", "ArmorItems", "HandItems",
-            "Items", "ChestedHorse", "DecorItem", "Leash", "leash", "equipment"
+            "Items", "ChestedHorse", "DecorItem", "Leash", "leash", "equipment", "CustomName", "CustomNameVisible",
     };
 
     private static final Logger LOGGER = LogUtils.getLogger();

--- a/NMS/v1_21_7/src/main/java/com/bgsoftware/wildstacker/nms/v1_21_7/NMSAdapterImpl.java
+++ b/NMS/v1_21_7/src/main/java/com/bgsoftware/wildstacker/nms/v1_21_7/NMSAdapterImpl.java
@@ -126,7 +126,7 @@ public final class NMSAdapterImpl implements NMSAdapter {
             for (String key : ENTITY_NBT_TAGS_TO_REMOVE)
                 compoundTag.remove(key);
 
-            target.load(TagValueInput.create(scopedCollector, target.registryAccess(), tagValueOutput.buildResult()));
+            target.load(TagValueInput.create(scopedCollector, target.registryAccess(), compoundTag));
         }
     }
 

--- a/src/main/java/com/bgsoftware/wildstacker/objects/WStackedEntity.java
+++ b/src/main/java/com/bgsoftware/wildstacker/objects/WStackedEntity.java
@@ -472,10 +472,9 @@ public final class WStackedEntity extends WAsyncStackedObject<LivingEntity> impl
 
             plugin.getNMSAdapter().updateEntity(object, duplicate.getLivingEntity());
 
-            if (plugin.getSettings().keepFireEnabled) {
-                int ticks = object.getFireTicks();
-                if (ticks > 0) duplicate.getLivingEntity().setFireTicks(ticks);
-            }
+            if (plugin.getSettings().keepFireEnabled && object.getFireTicks() > 0)
+                duplicate.getLivingEntity().setFireTicks(160);
+
         }
 
         EventsCaller.callDuplicateSpawnEvent(this, duplicate);

--- a/src/main/java/com/bgsoftware/wildstacker/objects/WStackedEntity.java
+++ b/src/main/java/com/bgsoftware/wildstacker/objects/WStackedEntity.java
@@ -472,8 +472,10 @@ public final class WStackedEntity extends WAsyncStackedObject<LivingEntity> impl
 
             plugin.getNMSAdapter().updateEntity(object, duplicate.getLivingEntity());
 
-            if (plugin.getSettings().keepFireEnabled && object.getFireTicks() > -1)
-                duplicate.getLivingEntity().setFireTicks(160);
+            if (plugin.getSettings().keepFireEnabled) {
+                int ticks = object.getFireTicks();
+                if (ticks > 0) duplicate.getLivingEntity().setFireTicks(ticks);
+            }
         }
 
         EventsCaller.callDuplicateSpawnEvent(this, duplicate);

--- a/src/main/java/com/bgsoftware/wildstacker/utils/entity/logic/DeathSimulation.java
+++ b/src/main/java/com/bgsoftware/wildstacker/utils/entity/logic/DeathSimulation.java
@@ -156,7 +156,7 @@ public final class DeathSimulation {
             giveStatisticsToKiller(directKiller, (Player) sourceKiller, unstackAmount, stackedEntity);
         }
 
-        if (plugin.getSettings().keepFireEnabled && livingEntity.getFireTicks() > -1)
+        if (plugin.getSettings().keepFireEnabled && livingEntity.getFireTicks() > 0)
             livingEntity.setFireTicks(160);
 
         // We want to cache the killer of the entity


### PR DESCRIPTION
Hello,

related to https://github.com/BG-Software-LLC/WildStacker/issues/1065 it will fix the fire issue (now it's 0 instead of -1 so, why keep looking -1 if we can looking at 0).

Also I set tick value to the current value, it's more logical, right ? Like that 

In 1.21.5+ the addAdditionalSaveData is protected and the new method keep custom name in data, that's why after a breed without smart breed it will spawn entity with same name of the parent. If you know a better way let me know.

I find another class where getFireTicks is used, and I changed it to 0 too.

