### PR TITLE
Update SpawnersListener.java

### DIFF
--- a/src/main/java/com/bgsoftware/wildstacker/listeners/SpawnersListener.java
+++ b/src/main/java/com/bgsoftware/wildstacker/listeners/SpawnersListener.java
@@ -297,7 +297,7 @@ public final class SpawnersListener implements Listener {
 
                 spawnerItemAmount = targetSpawner.getStackAmount();
             }
-
+            if(spawnerType==null) spawnerType = EntityType.PIG;
             finishSpawnerPlace(e.getPlayer(), stackedSpawner, amountToCharge, replaceAir, usedHand, limitItem,
                     spawnerType, spawnerItemAmount);
         } catch (Exception ex) {
@@ -321,8 +321,9 @@ public final class SpawnersListener implements Listener {
 
         if (limitItem != null)
             ItemUtils.addItem(limitItem, player.getInventory(), player.getLocation());
-
-        Locale.SPAWNER_PLACE.send(player, EntityUtils.getFormattedType(spawnerType.name()), spawnerItemAmount, GeneralUtils.format(amountToCharge));
+        String STYPE = "PIG";
+        if(spawnerType!=null) STYPE = spawnerType.name();
+        Locale.SPAWNER_PLACE.send(player, EntityUtils.getFormattedType(STYPE), spawnerItemAmount, GeneralUtils.format(amountToCharge));
 
         alreadySpawnersPlacedPlayers.remove(player.getUniqueId());
     }


### PR DESCRIPTION
[00:30:01 ERROR]: Could not pass event BlockPlaceEvent to WildStacker v2025.1-b148 java.lang.NullPointerException: Cannot invoke "org.bukkit.entity.EntityType.name()" because "spawnerType" is null
        at WildStacker-2025.1-b148.jar/com.bgsoftware.wildstacker.listeners.SpawnersListener.finishSpawnerPlace(SpawnersListener.java:325) ~[WildStacker-2025.1-b148.jar:?]
        at WildStacker-2025.1-b148.jar/com.bgsoftware.wildstacker.listeners.SpawnersListener.onBlockPlace(SpawnersListener.java:301) ~[WildStacker-2025.1-b148.jar:?]