### PR TITLE
Fix #1094

### DIFF
--- a/NMS/src/main/templates/AbstractNMSEntities.java.template
+++ b/NMS/src/main/templates/AbstractNMSEntities.java.template
@@ -624,8 +624,12 @@ public abstract class AbstractNMSEntities implements NMSEntities {
             });
         }
 
-        if (isEventCancelled.get())
+        if (isEventCancelled.get()) {
+            if (!pickupItem.isAlive()) {
+                itemEntity.discard();
+            }
             return true;
+        }
 
         int pickupCount = originalItemCount - (pickupItem.isAlive() ? pickupItem.getItem().getCount() : 0);
 


### PR DESCRIPTION
It should be safe to assume that the pickup isn't dead when the event is cancelled. If it is dead then a plugin has likely done manual handling of the pickup event and killed the dropped item.

I only tested against a similar setup used in the issue this fixes, but it shouldn't have any side effects from plugins cancelling the event without killing the dropped item.