### PR TITLE
Another attempt at a fix for #1094

### DIFF
--- a/NMS/src/main/templates/AbstractNMSEntities.java.template
+++ b/NMS/src/main/templates/AbstractNMSEntities.java.template
@@ -555,6 +555,22 @@ public abstract class AbstractNMSEntities implements NMSEntities {
             mob.spawnAnim();
     }
 
+    private int getInventorySum(LivingEntity livingEntity) {
+        List<ItemStack> items = null;
+        if (livingEntity instanceof Player) {
+            items = ((Player) livingEntity).getInventory().getContents();
+        }
+
+        if (items == null) return 0;
+
+        int sum = 0;
+        for (ItemStack itemStack : items) {
+            sum += itemStack.getCount();
+        }
+
+        return sum;
+    }
+
     @Override
     public boolean handleItemPickup(org.bukkit.entity.LivingEntity bukkitLivingEntity, StackedItem stackedItem, int remaining) {
         LivingEntity livingEntity = ((CraftLivingEntity) bukkitLivingEntity).getHandle();
@@ -598,6 +614,7 @@ public abstract class AbstractNMSEntities implements NMSEntities {
         int originalPickupDelay = itemEntity.pickupDelay;
         boolean isDifferentPickupItem = pickupItem != itemEntity;
         boolean actualItemDupe = originalItemCount != stackAmount;
+        int inventorySum = getInventorySum(livingEntity);
 
         AtomicBoolean isEventCancelled = new AtomicBoolean(false);
         try {
@@ -625,8 +642,12 @@ public abstract class AbstractNMSEntities implements NMSEntities {
         }
 
         if (isEventCancelled.get()) {
-            if (!pickupItem.isAlive()) {
-                itemEntity.discard();
+            int newInventorySum = getInventorySum(livingEntity);
+            if (inventorySum < newInventorySum) {
+                stackedItem.decreaseStackAmount(newInventorySum - inventorySum, true);
+                if (stackedItem.getStackAmount() <= 0) {
+                    itemEntity.discard();
+                }
             }
             return true;
         }


### PR DESCRIPTION
This is terrible and increases the CPU load due to having to loop over the inventory up to two times if the event was cancelled.

That being said though, I wasn't able to have issues when `fix-stack` was set to true or false.

If this doesn't get merged, I recommend reverting my previous attempt as that causes more issues than it fixes. Overall this is just a hacky fix until a better solution is found. Unfortunately I don't understand this plugin enough to provide one.