### PR TITLE
Better custom-names feature

### DIFF
--- a/Hooks/ShopGUIPlus18/src/main/java/com/bgsoftware/wildstacker/hooks/ShopGUIPlus18Hook.java
+++ b/Hooks/ShopGUIPlus18/src/main/java/com/bgsoftware/wildstacker/hooks/ShopGUIPlus18Hook.java
@@ -1,7 +1,7 @@
 package com.bgsoftware.wildstacker.hooks;
 
 import com.bgsoftware.wildstacker.WildStackerPlugin;
-import com.bgsoftware.wildstacker.utils.entity.EntityUtils;
+import com.bgsoftware.wildstacker.utils.names.CustomNames;
 import net.brcdev.shopgui.ShopGuiPlusApi;
 import net.brcdev.shopgui.provider.spawner.SpawnerProvider;
 import org.bukkit.entity.EntityType;
@@ -33,12 +33,16 @@ public final class ShopGUIPlus18Hook {
 
         @Override
         public String getSpawnerEntityId(ItemStack itemStack) {
-            return plugin.getProviders().getSpawnersProvider().getSpawnerType(itemStack).name();
+            return getSpawnerEntityType(itemStack).name();
         }
 
         @Override
         public String getSpawnerEntityName(ItemStack itemStack) {
-            return EntityUtils.getFormattedType(getSpawnerEntityId(itemStack));
+            return CustomNames.getSpawnerCustomName(getSpawnerEntityType(itemStack));
+        }
+
+        private EntityType getSpawnerEntityType(ItemStack itemStack) {
+            return plugin.getProviders().getSpawnersProvider().getSpawnerType(itemStack);
         }
 
     }

--- a/NMS/src/main/templates/AbstractNMSSpawners.java.template
+++ b/NMS/src/main/templates/AbstractNMSSpawners.java.template
@@ -10,7 +10,7 @@ import com.bgsoftware.wildstacker.nms.${NMS_VERSION}.spawner.SpawnerWatcherTicki
 import com.bgsoftware.wildstacker.nms.${NMS_VERSION}.spawner.StackedBaseSpawner;
 import com.bgsoftware.wildstacker.nms.${NMS_VERSION}.spawner.SyncedCreatureSpawnerImpl;
 import com.bgsoftware.wildstacker.objects.WStackedSpawner;
-import com.bgsoftware.wildstacker.utils.entity.EntityUtils;
+import com.bgsoftware.wildstacker.utils.names.CustomNames;
 import com.bgsoftware.wildstacker.utils.spawners.SpawnerCachedData;
 import com.bgsoftware.wildstacker.utils.spawners.SyncedCreatureSpawner;
 import net.minecraft.core.BlockPos;
@@ -161,7 +161,7 @@ public abstract class AbstractNMSSpawners implements NMSSpawners {
     }
 
     protected final void createCondition(String id, BiPredicate<ServerLevel, BlockPos> predicate, EntityType... entityTypes) {
-        SpawnCondition spawnCondition = SpawnCondition.register(new SpawnCondition(id, EntityUtils.format(id)) {
+        SpawnCondition spawnCondition = SpawnCondition.register(new SpawnCondition(id, CustomNames.format(id)) {
             @Override
             public boolean test(Location location) {
                 return predicate.test(((CraftWorld) location.getWorld()).getHandle(),

--- a/NMS/v1_12_R1/src/main/java/com/bgsoftware/wildstacker/nms/v1_12_R1/NMSSpawnersImpl.java
+++ b/NMS/v1_12_R1/src/main/java/com/bgsoftware/wildstacker/nms/v1_12_R1/NMSSpawnersImpl.java
@@ -9,7 +9,7 @@ import com.bgsoftware.wildstacker.nms.v1_12_R1.spawner.StackedMobSpawner;
 import com.bgsoftware.wildstacker.nms.v1_12_R1.spawner.SyncedCreatureSpawnerImpl;
 import com.bgsoftware.wildstacker.nms.v1_12_R1.spawner.TileEntityMobSpawnerWatcher;
 import com.bgsoftware.wildstacker.objects.WStackedSpawner;
-import com.bgsoftware.wildstacker.utils.entity.EntityUtils;
+import com.bgsoftware.wildstacker.utils.names.CustomNames;
 import com.bgsoftware.wildstacker.utils.spawners.SpawnerCachedData;
 import com.bgsoftware.wildstacker.utils.spawners.SyncedCreatureSpawner;
 import net.minecraft.server.v1_12_R1.BiomeBase;
@@ -46,7 +46,7 @@ public final class NMSSpawnersImpl implements NMSSpawners {
     private static final WildStackerPlugin plugin = WildStackerPlugin.getPlugin();
 
     private static void createCondition(String id, BiPredicate<World, BlockPosition> predicate, EntityType... entityTypes) {
-        SpawnCondition spawnCondition = SpawnCondition.register(new SpawnCondition(id, EntityUtils.format(id)) {
+        SpawnCondition spawnCondition = SpawnCondition.register(new SpawnCondition(id, CustomNames.format(id)) {
             @Override
             public boolean test(Location location) {
                 return predicate.test(((CraftWorld) location.getWorld()).getHandle(),

--- a/NMS/v1_16_R3/src/main/java/com/bgsoftware/wildstacker/nms/v1_16_R3/NMSSpawnersImpl.java
+++ b/NMS/v1_16_R3/src/main/java/com/bgsoftware/wildstacker/nms/v1_16_R3/NMSSpawnersImpl.java
@@ -9,7 +9,7 @@ import com.bgsoftware.wildstacker.nms.v1_16_R3.spawner.StackedMobSpawner;
 import com.bgsoftware.wildstacker.nms.v1_16_R3.spawner.SyncedCreatureSpawnerImpl;
 import com.bgsoftware.wildstacker.nms.v1_16_R3.spawner.TileEntityMobSpawnerWatcher;
 import com.bgsoftware.wildstacker.objects.WStackedSpawner;
-import com.bgsoftware.wildstacker.utils.entity.EntityUtils;
+import com.bgsoftware.wildstacker.utils.names.CustomNames;
 import com.bgsoftware.wildstacker.utils.spawners.SpawnerCachedData;
 import com.bgsoftware.wildstacker.utils.spawners.SyncedCreatureSpawner;
 import net.minecraft.server.v1_16_R3.BiomeBase;
@@ -52,7 +52,7 @@ public final class NMSSpawnersImpl implements NMSSpawners {
     private static final WildStackerPlugin plugin = WildStackerPlugin.getPlugin();
 
     private static void createCondition(String id, BiPredicate<World, BlockPosition> predicate, EntityType... entityTypes) {
-        SpawnCondition spawnCondition = SpawnCondition.register(new SpawnCondition(id, EntityUtils.format(id)) {
+        SpawnCondition spawnCondition = SpawnCondition.register(new SpawnCondition(id, CustomNames.format(id)) {
             @Override
             public boolean test(Location location) {
                 return predicate.test(((CraftWorld) location.getWorld()).getHandle(),

--- a/NMS/v1_7_R4/src/main/java/com/bgsoftware/wildstacker/nms/v1_7_R4/NMSSpawnersImpl.java
+++ b/NMS/v1_7_R4/src/main/java/com/bgsoftware/wildstacker/nms/v1_7_R4/NMSSpawnersImpl.java
@@ -10,7 +10,7 @@ import com.bgsoftware.wildstacker.nms.v1_7_R4.spawner.SyncedCreatureSpawnerImpl;
 import com.bgsoftware.wildstacker.nms.v1_7_R4.spawner.TileEntityMobSpawnerWatcher;
 import com.bgsoftware.wildstacker.nms.v1_7_R4.world.BlockPosition;
 import com.bgsoftware.wildstacker.objects.WStackedSpawner;
-import com.bgsoftware.wildstacker.utils.entity.EntityUtils;
+import com.bgsoftware.wildstacker.utils.names.CustomNames;
 import com.bgsoftware.wildstacker.utils.spawners.SpawnerCachedData;
 import com.bgsoftware.wildstacker.utils.spawners.SyncedCreatureSpawner;
 import net.minecraft.server.v1_7_R4.BiomeBase;
@@ -43,7 +43,7 @@ public final class NMSSpawnersImpl implements NMSSpawners {
     private static final WildStackerPlugin plugin = WildStackerPlugin.getPlugin();
 
     private static void createCondition(String id, BiPredicate<World, BlockPosition> predicate, EntityType... entityTypes) {
-        SpawnCondition spawnCondition = SpawnCondition.register(new SpawnCondition(id, EntityUtils.format(id)) {
+        SpawnCondition spawnCondition = SpawnCondition.register(new SpawnCondition(id, CustomNames.format(id)) {
             @Override
             public boolean test(Location location) {
                 return predicate.test(((CraftWorld) location.getWorld()).getHandle(),

--- a/NMS/v1_8_R3/src/main/java/com/bgsoftware/wildstacker/nms/v1_8_R3/NMSSpawnersImpl.java
+++ b/NMS/v1_8_R3/src/main/java/com/bgsoftware/wildstacker/nms/v1_8_R3/NMSSpawnersImpl.java
@@ -9,7 +9,7 @@ import com.bgsoftware.wildstacker.nms.v1_8_R3.spawner.StackedMobSpawner;
 import com.bgsoftware.wildstacker.nms.v1_8_R3.spawner.SyncedCreatureSpawnerImpl;
 import com.bgsoftware.wildstacker.nms.v1_8_R3.spawner.TileEntityMobSpawnerWatcher;
 import com.bgsoftware.wildstacker.objects.WStackedSpawner;
-import com.bgsoftware.wildstacker.utils.entity.EntityUtils;
+import com.bgsoftware.wildstacker.utils.names.CustomNames;
 import com.bgsoftware.wildstacker.utils.spawners.SpawnerCachedData;
 import com.bgsoftware.wildstacker.utils.spawners.SyncedCreatureSpawner;
 import net.minecraft.server.v1_8_R3.BiomeBase;
@@ -42,7 +42,7 @@ public final class NMSSpawnersImpl implements NMSSpawners {
     private static final WildStackerPlugin plugin = WildStackerPlugin.getPlugin();
 
     private static void createCondition(String id, BiPredicate<World, BlockPosition> predicate, EntityType... entityTypes) {
-        SpawnCondition spawnCondition = SpawnCondition.register(new SpawnCondition(id, EntityUtils.format(id)) {
+        SpawnCondition spawnCondition = SpawnCondition.register(new SpawnCondition(id, CustomNames.format(id)) {
             @Override
             public boolean test(Location location) {
                 return predicate.test(((CraftWorld) location.getWorld()).getHandle(),

--- a/src/main/java/com/bgsoftware/wildstacker/Locale.java
+++ b/src/main/java/com/bgsoftware/wildstacker/Locale.java
@@ -21,7 +21,7 @@ public final class Locale {
     public static Locale BARREL_TOGGLE_ON = new Locale("BARREL_TOGGLE_ON");
     public static Locale BARREL_TOGGLE_OFF = new Locale("BARREL_TOGGLE_OFF");
     public static Locale BARREL_NO_PERMISSION = new Locale("BARREL_NO_PERMISSION");
-    public static Locale CHUNK_LIMIT_EXCEEDED = new Locale("CHUNK_LIMIT_EXCEEDED");
+    public static Locale BARREL_CHUNK_LIMIT_EXCEEDED = new Locale("BARREL_CHUNK_LIMIT_EXCEEDED");
     public static Locale COMMAND_USAGE = new Locale("COMMAND_USAGE");
     public static Locale ENTITY_NAMES_TOGGLE_ON = new Locale("ENTITY_NAMES_TOGGLE_ON");
     public static Locale ENTITY_NAMES_TOGGLE_OFF = new Locale("ENTITY_NAMES_TOGGLE_OFF");
@@ -60,6 +60,7 @@ public final class Locale {
     public static Locale SPAWNER_CHANGE_NOT_ENOUGH_ITEMS = new Locale("SPAWNER_CHANGE_NOT_ENOUGH_ITEMS");
     public static Locale SPAWNER_UPGRADE_NOT_ENOUGH_MONEY = new Locale("SPAWNER_UPGRADE_NOT_ENOUGH_MONEY");
     public static Locale SPAWNER_UPGRADE_SUCCESS = new Locale("SPAWNER_UPGRADE_SUCCESS");
+    public static Locale SPAWNER_CHUNK_LIMIT_EXCEEDED = new Locale("SPAWNER_CHUNK_LIMIT_EXCEEDED");
     public static Locale STACK_GIVE_PLAYER = new Locale("STACK_GIVE_PLAYER");
     public static Locale STACK_RECEIVE = new Locale("STACK_RECEIVE");
     public static Locale STACK_INFO_INVALID = new Locale("STACK_INFO_INVALID");

--- a/src/main/java/com/bgsoftware/wildstacker/command/commands/CommandGive.java
+++ b/src/main/java/com/bgsoftware/wildstacker/command/commands/CommandGive.java
@@ -4,10 +4,8 @@ import com.bgsoftware.wildstacker.Locale;
 import com.bgsoftware.wildstacker.WildStackerPlugin;
 import com.bgsoftware.wildstacker.api.upgrades.SpawnerUpgrade;
 import com.bgsoftware.wildstacker.command.ICommand;
-import com.bgsoftware.wildstacker.utils.ServerVersion;
-import com.bgsoftware.wildstacker.utils.entity.EntityUtils;
 import com.bgsoftware.wildstacker.utils.items.ItemUtils;
-import com.bgsoftware.wildstacker.utils.legacy.Materials;
+import com.bgsoftware.wildstacker.utils.names.CustomNames;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
@@ -15,7 +13,6 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -79,9 +76,6 @@ public final class CommandGive implements ICommand {
             return;
         }
 
-        ItemStack itemStack;
-        String typeName;
-
         int stackSize;
 
         try {
@@ -91,14 +85,15 @@ public final class CommandGive implements ICommand {
             return;
         }
 
-        boolean reformatItem = true;
+        ItemStack itemStack;
+        String typeName;
 
         if (args[2].equalsIgnoreCase("egg")) {
             EntityType entityType;
 
             try {
                 entityType = EntityType.valueOf(args[3].toUpperCase());
-                typeName = EntityUtils.getFormattedType(entityType.name());
+                typeName = CustomNames.getEggCustomName(entityType);
             } catch (IllegalArgumentException ex) {
                 Locale.INVALID_ENTITY.send(sender, args[3]);
                 return;
@@ -115,27 +110,13 @@ public final class CommandGive implements ICommand {
                 }
             }
 
-            Material eggType = Materials.getSpawnEgg(entityType);
-            if (eggType == null || ServerVersion.isLegacy()) {
-                if (ServerVersion.isLegacy()) {
-                    itemStack = new ItemStack(Material.MONSTER_EGG);
-                    ItemUtils.setEntityType(itemStack, entityType);
-                } else {
-                    itemStack = ItemUtils.getItemNMSEntityType(entityType);
-                }
-            } else {
-                itemStack = new ItemStack(eggType);
-            }
-
-            itemStack = ItemUtils.setSpawnerItemAmount(itemStack, stackSize);
-            if (spawnerUpgrade != null && !spawnerUpgrade.isDefault())
-                itemStack = ItemUtils.setSpawnerUpgrade(itemStack, spawnerUpgrade.getId());
+            itemStack = ItemUtils.getEggItem(entityType, stackSize, spawnerUpgrade);
         } else if (args[2].equalsIgnoreCase("spawner")) {
             EntityType entityType;
 
             try {
                 entityType = EntityType.valueOf(args[3].toUpperCase());
-                typeName = EntityUtils.getFormattedType(entityType.name());
+                typeName = CustomNames.getSpawnerCustomName(entityType);
             } catch (IllegalArgumentException ex) {
                 Locale.INVALID_ENTITY.send(sender, args[3]);
                 return;
@@ -154,14 +135,12 @@ public final class CommandGive implements ICommand {
 
             itemStack = plugin.getProviders().getSpawnersProvider().getSpawnerItem(entityType,
                     stackSize, spawnerUpgrade);
-
-            reformatItem = false;
         } else if (args[2].equalsIgnoreCase("barrel")) {
             Material barrelType;
 
             try {
                 barrelType = Material.getMaterial(args[3].toUpperCase());
-                typeName = ItemUtils.getFormattedType(new ItemStack(barrelType));
+                typeName = CustomNames.getBarrelCustomName(new ItemStack(barrelType));
             } catch (IllegalArgumentException | NullPointerException ex) {
                 Locale.INVALID_BARREL.send(sender, args[3]);
                 return;
@@ -172,23 +151,10 @@ public final class CommandGive implements ICommand {
                 return;
             }
 
-            itemStack = new ItemStack(barrelType);
-            itemStack = ItemUtils.setSpawnerItemAmount(itemStack, stackSize);
+            itemStack = ItemUtils.getBarrelItem(barrelType, stackSize);
         } else {
             Locale.INVALID_TYPE.send(sender);
             return;
-        }
-
-        if (reformatItem) {
-            args[2] = args[2].substring(0, 1).toUpperCase() + args[2].substring(1).toLowerCase();
-
-            ItemMeta itemMeta = itemStack.getItemMeta();
-            itemMeta.setDisplayName(WildStackerPlugin.getPlugin().getSettings().giveItemName
-                    .replace("{0}", stackSize + "")
-                    .replace("{1}", typeName)
-                    .replace("{2}", args[2])
-            );
-            itemStack.setItemMeta(itemMeta);
         }
 
         ItemUtils.addItem(itemStack, target.getInventory(), target.getLocation());

--- a/src/main/java/com/bgsoftware/wildstacker/command/commands/CommandInfo.java
+++ b/src/main/java/com/bgsoftware/wildstacker/command/commands/CommandInfo.java
@@ -7,9 +7,8 @@ import com.bgsoftware.wildstacker.api.objects.StackedSpawner;
 import com.bgsoftware.wildstacker.command.ICommand;
 import com.bgsoftware.wildstacker.objects.WStackedBarrel;
 import com.bgsoftware.wildstacker.objects.WStackedSpawner;
-import com.bgsoftware.wildstacker.utils.entity.EntityUtils;
-import com.bgsoftware.wildstacker.utils.items.ItemUtils;
 import com.bgsoftware.wildstacker.utils.legacy.Materials;
+import com.bgsoftware.wildstacker.utils.names.CustomNames;
 import com.google.common.collect.Sets;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -68,7 +67,7 @@ public final class CommandInfo implements ICommand {
             StackedSpawner stackedSpawner = WStackedSpawner.of(targetBlock);
 
             Locale.SPAWNER_INFO_HEADER.send(sender);
-            Locale.SPAWNER_INFO_TYPE.send(sender, EntityUtils.getFormattedType(stackedSpawner.getSpawnedType().name()));
+            Locale.SPAWNER_INFO_TYPE.send(sender, CustomNames.getSpawnerCustomName(stackedSpawner.getSpawnedType()));
             Locale.SPAWNER_INFO_AMOUNT.send(sender, stackedSpawner.getStackAmount());
             Locale.SPAWNER_INFO_UPGRADE.send(sender, stackedSpawner.getUpgrade().getName());
             Locale.SPAWNER_INFO_FOOTER.send(sender);
@@ -77,7 +76,7 @@ public final class CommandInfo implements ICommand {
             StackedBarrel stackedBarrel = WStackedBarrel.of(targetBlock);
 
             Locale.BARREL_INFO_HEADER.send(sender);
-            Locale.BARREL_INFO_TYPE.send(sender, ItemUtils.getFormattedType(stackedBarrel.getBarrelItem(1)));
+            Locale.BARREL_INFO_TYPE.send(sender, CustomNames.getBarrelCustomName(stackedBarrel.getBarrelItem(1)));
             Locale.BARREL_INFO_AMOUNT.send(sender, stackedBarrel.getStackAmount());
             Locale.BARREL_INFO_FOOTER.send(sender);
             return;

--- a/src/main/java/com/bgsoftware/wildstacker/handlers/SettingsHandler.java
+++ b/src/main/java/com/bgsoftware/wildstacker/handlers/SettingsHandler.java
@@ -40,13 +40,7 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.inventory.ItemStack;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -57,6 +51,7 @@ public final class SettingsHandler {
     public final String[] CONFIG_IGNORED_SECTIONS = {"merge-radius", "limits", "minimum-required", "default-unstack",
             "break-slots", "manage-menu", "break-charge", "place-charge", "spawners-override.spawn-conditions",
             "spawner-upgrades.ladders"};
+    public final String[] CUSTOM_NAMES_IGNORED_SECTIONS = {"global", "eggs", "items", "entities", "spawners", "barrels"};
 
     // Database settings
     public final String databaseType;
@@ -72,15 +67,18 @@ public final class SettingsHandler {
     public final long databaseMySQLMaxLifetime;
 
     //Global settings
-    public final String giveItemName, killTaskTimeCommand;
+    public final String killTaskTimeCommand;
     public final ItemStack inspectTool, simulateTool;
     public final boolean deleteInvalidWorlds, killTaskStackedEntities, killTaskUnstackedEntities,
             killTaskStackedItems, killTaskUnstackedItems, killTaskSyncClearLagg;
-    public final Map<String, String> customNames;
     public final long killTaskInterval;
     public final Fast2EnumsArray<EntityType, SpawnCause> killTaskEntitiesWhitelist, killTaskEntitiesBlacklist;
     public final FastEnumArray<Material> killTaskItemsWhitelist, killTaskItemsBlacklist;
     public final List<String> killTaskEntitiesWorlds, killTaskItemsWorlds;
+
+    //Eggs settings
+    public final String eggsItemName;
+    public final List<String> eggsItemLore;
 
     //Items settings
     public final boolean itemsStackingEnabled, itemsParticlesEnabled, itemsFixStackEnabled, itemsDisplayEnabled,
@@ -124,9 +122,9 @@ public final class SettingsHandler {
             spawnerUpgradesMultiplyStackAmount, listenPaperPreSpawnEvent, spawnersUnstackedCustomName;
     public final int explosionsBreakChance, explosionsBreakPercentage, explosionsBreakMinimum, explosionsAmountPercentage,
             explosionsAmountMinimum, silkTouchBreakChance, silkTouchMinimumLevel, spawnersChunkLimit;
-    public final List<String> spawnersDisabledWorlds, spawnerItemLore, silkWorlds, explosionsWorlds;
+    public final List<String> spawnersDisabledWorlds, spawnersItemLore, silkWorlds, explosionsWorlds;
     public final FastEnumArray<EntityType> blacklistedSpawners, whitelistedSpawners;
-    public final String spawnersCustomName, spawnerItemName, inventoryTweaksPermission, inventoryTweaksCommand;
+    public final String spawnersCustomName, spawnersItemName, inventoryTweaksPermission, inventoryTweaksCommand;
     public final NameBuilder<StackedSpawner> spawnersNameBuilder;
     public final FastEnumMap<EntityType, Integer> spawnersMergeRadius, spawnersLimits;
     public final List<ParticleWrapper> spawnersParticles;
@@ -142,6 +140,8 @@ public final class SettingsHandler {
     public final FastEnumArray<Material> blacklistedBarrels, whitelistedBarrels;
     public final FastEnumMap<Material, Integer> barrelsMergeRadius, barrelsLimits;
     public final List<ParticleWrapper> barrelsParticles;
+    public final String barrelsItemName;
+    public final List<String> barrelsItemLore;
 
     //Buckets settings
     public final boolean bucketsStackerEnabled;
@@ -151,6 +151,16 @@ public final class SettingsHandler {
     //Stews settings
     public final boolean stewsStackingEnabled;
     public final int stewsMaxStack;
+
+    //Custom names settings
+    public final Map<String, String> globalCustomNames;
+    public final Map<String, String> eggsCustomNames;
+    public final Map<String, String> itemsCustomNames;
+    public final Map<String, String> entitiesCustomNames;
+    public final Map<String, String> spawnersCustomNames;
+    public final Map<String, String> barrelsCustomNames;
+
+    //Particles settings
     private YamlConfiguration particlesYaml = null;
 
     public SettingsHandler(WildStackerPlugin plugin) {
@@ -184,12 +194,6 @@ public final class SettingsHandler {
         databaseMySQLWaitTimeout = cfg.getLong("database.waitTimeout");
         databaseMySQLMaxLifetime = cfg.getLong("database.maxLifetime");
 
-        giveItemName = ChatColor.translateAlternateColorCodes('&', cfg.getString("give-item-name", "&6x{0} &f&o{1} {2}"));
-        SPAWNERS_PATTERN = Pattern.compile(giveItemName
-                .replace("{0}", "(.*)")
-                .replace("{1}", "(.*)")
-                .replace("{2}", "(.*)")
-        );
         inspectTool = new ItemBuilder(Material.valueOf(cfg.getString("inspect-tool.type")), cfg.getInt("inspect-tool.data", 0))
                 .withName(cfg.getString("inspect-tool.name"))
                 .withLore(cfg.getStringList("inspect-tool.lore")).build();
@@ -212,8 +216,18 @@ public final class SettingsHandler {
         killTaskItemsWhitelist = FastEnumArray.fromList(cfg.getStringList("kill-task.kill-items.whitelist"), Material.class);
         killTaskItemsBlacklist = FastEnumArray.fromList(cfg.getStringList("kill-task.kill-items.blacklist"), Material.class);
         killTaskItemsWorlds = cfg.getStringList("kill-task.kill-items.worlds");
-        customNames = new HashMap<>();
+
+        globalCustomNames = new HashMap<>();
+        eggsCustomNames = new HashMap<>();
+        itemsCustomNames = new HashMap<>();
+        entitiesCustomNames = new HashMap<>();
+        spawnersCustomNames = new HashMap<>();
+        barrelsCustomNames = new HashMap<>();
         loadCustomNames(plugin);
+
+        eggsItemName = ChatColor.translateAlternateColorCodes('&', cfg.getString("eggs.egg-item.name", "&6x{0} &f&o{1} Egg{2}"));
+        eggsItemLore = cfg.getStringList("eggs.egg-item.lore").stream().map(line ->
+                ChatColor.translateAlternateColorCodes('&', line)).collect(Collectors.toList());
 
         itemsStackingEnabled = cfg.getBoolean("items.enabled", true);
         itemsMergeRadius = FastEnumMap.fromSection(cfg.getConfigurationSection("items.merge-radius"), Material.class);
@@ -340,9 +354,14 @@ public final class SettingsHandler {
                 new NamePlaceholder<>("{2}", stackedSpawner -> ((WStackedSpawner) stackedSpawner).getCachedDisplayName().toUpperCase()),
                 new NamePlaceholder<>("{3}", stackedSpawner -> stackedSpawner.getUpgrade().getDisplayName())
         );
-        spawnerItemName = ChatColor.translateAlternateColorCodes('&', cfg.getString("spawners.spawner-item.name", "&e{0} &fSpawner"));
-        spawnerItemLore = cfg.getStringList("spawners.spawner-item.lore").stream().map(line ->
+        spawnersItemName = ChatColor.translateAlternateColorCodes('&', cfg.getString("spawners.spawner-item.name", "&6x{0} &f&o{1} Spawner{2}"));
+        spawnersItemLore = cfg.getStringList("spawners.spawner-item.lore").stream().map(line ->
                 ChatColor.translateAlternateColorCodes('&', line)).collect(Collectors.toList());
+        SPAWNERS_PATTERN = Pattern.compile(spawnersItemName
+                .replace("{0}", "(.*)")
+                .replace("{1}", "(.*)")
+                .replace("{2}", "(.*)")
+        );
         silkTouchSpawners = cfg.getBoolean("spawners.silk-touch.enabled", true);
         dropToInventory = cfg.getBoolean("spawners.silk-touch.drop-to-inventory", true);
         silkWorlds = cfg.getStringList("spawners.silk-touch.worlds");
@@ -516,6 +535,9 @@ public final class SettingsHandler {
                 new NamePlaceholder<>("{1}", stackedBarrel -> ((WStackedBarrel) stackedBarrel).getCachedDisplayName()),
                 new NamePlaceholder<>("{2}", stackedBarrel -> ((WStackedBarrel) stackedBarrel).getCachedDisplayName().toUpperCase())
         );
+        barrelsItemName = ChatColor.translateAlternateColorCodes('&', cfg.getString("barrels.barrel-item.name", "&6x{0} &f&o{1} Barrel"));
+        barrelsItemLore = cfg.getStringList("barrels.barrel-item.lore").stream().map(line ->
+                ChatColor.translateAlternateColorCodes('&', line)).collect(Collectors.toList());
         blacklistedBarrels = FastEnumArray.fromList(cfg.getStringList("barrels.blacklist"), Material.class);
         whitelistedBarrels = FastEnumArray.fromList(cfg.getStringList("barrels.whitelist"), Material.class);
         barrelsChunkLimit = cfg.getInt("barrels.chunk-limit", 0);
@@ -574,11 +596,30 @@ public final class SettingsHandler {
         if (!file.exists())
             plugin.saveResource("custom-names.yml", false);
 
-        YamlConfiguration cfg = YamlConfiguration.loadConfiguration(file);
+        CommentedConfiguration cfg = CommentedConfiguration.loadConfiguration(file);
+
+        customNamesConvertor(cfg);
+
+        try {
+            cfg.syncWithConfig(file, plugin.getResource("custom-names.yml"), CUSTOM_NAMES_IGNORED_SECTIONS);
+            cfg.save(file);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
 
         if (cfg.getBoolean("enabled", true)) {
-            for (String key : cfg.getConfigurationSection("").getKeys(false))
-                customNames.put(key, ChatColor.translateAlternateColorCodes('&', cfg.getString(key)));
+            for (String key : cfg.getConfigurationSection("global").getKeys(false))
+                globalCustomNames.put(key, ChatColor.translateAlternateColorCodes('&', cfg.getString("global." + key)));
+            for (String key : cfg.getConfigurationSection("eggs").getKeys(false))
+                eggsCustomNames.put(key, ChatColor.translateAlternateColorCodes('&', cfg.getString("eggs." + key)));
+            for (String key : cfg.getConfigurationSection("items").getKeys(false))
+                itemsCustomNames.put(key, ChatColor.translateAlternateColorCodes('&', cfg.getString("items." + key)));
+            for (String key : cfg.getConfigurationSection("entities").getKeys(false))
+                entitiesCustomNames.put(key, ChatColor.translateAlternateColorCodes('&', cfg.getString("entities." + key)));
+            for (String key : cfg.getConfigurationSection("spawners").getKeys(false))
+                spawnersCustomNames.put(key, ChatColor.translateAlternateColorCodes('&', cfg.getString("spawners." + key)));
+            for (String key : cfg.getConfigurationSection("barrels").getKeys(false))
+                barrelsCustomNames.put(key, ChatColor.translateAlternateColorCodes('&', cfg.getString("barrels." + key)));
         }
     }
 
@@ -616,7 +657,42 @@ public final class SettingsHandler {
         return particleWrappers;
     }
 
+    private void customNamesConvertor(YamlConfiguration cfg) {
+        if (!cfg.isConfigurationSection("global")) {
+            Map<String, String> global = new HashMap<>();
+            Set<String> ignored = new HashSet<>(Arrays.asList(CUSTOM_NAMES_IGNORED_SECTIONS));
+            for (String key : cfg.getKeys(false)) {
+                if (key.equals("enabled") || ignored.contains(key))
+                    continue;
+                global.put(key, cfg.getString(key));
+            }
+            cfg.createSection("global");
+            for (Map.Entry<String, String> entry : global.entrySet()) {
+                cfg.set("global." + entry.getKey(), entry.getValue());
+                cfg.set(entry.getKey(), null);
+            }
+        }
+        if (!cfg.isConfigurationSection("eggs"))
+            cfg.createSection("eggs");
+        if (!cfg.isConfigurationSection("items"))
+            cfg.createSection("items");
+        if (!cfg.isConfigurationSection("entities"))
+            cfg.createSection("entities");
+        if (!cfg.isConfigurationSection("spawners"))
+            cfg.createSection("spawners");
+        if (!cfg.isConfigurationSection("barrels"))
+            cfg.createSection("barrels");
+    }
+
     private void dataConvertor(YamlConfiguration cfg) {
+        if (!cfg.isConfigurationSection("eggs.egg-item")) {
+            String name = cfg.getString("give-item-name").replace("{2}", "Egg");
+            cfg.set("eggs.egg-item.name", name);
+        }
+        if (!cfg.isConfigurationSection("barrels.barrel-item")) {
+            String name = cfg.getString("give-item-name").replace("{2}", "Barrel");
+            cfg.set("barrels.barrel-item.name", name);
+        }
         if (cfg.contains("items.kill-all"))
             cfg.set("kill-task.stacked-items", cfg.getBoolean("items.kill-all"));
         if (cfg.contains("items.check-range"))

--- a/src/main/java/com/bgsoftware/wildstacker/hooks/SpawnersProvider_Default.java
+++ b/src/main/java/com/bgsoftware/wildstacker/hooks/SpawnersProvider_Default.java
@@ -3,10 +3,10 @@ package com.bgsoftware.wildstacker.hooks;
 import com.bgsoftware.wildstacker.WildStackerPlugin;
 import com.bgsoftware.wildstacker.api.objects.StackedSpawner;
 import com.bgsoftware.wildstacker.api.upgrades.SpawnerUpgrade;
-import com.bgsoftware.wildstacker.utils.entity.EntityUtils;
 import com.bgsoftware.wildstacker.utils.events.EventsCaller;
 import com.bgsoftware.wildstacker.utils.items.ItemUtils;
 import com.bgsoftware.wildstacker.utils.legacy.Materials;
+import com.bgsoftware.wildstacker.utils.names.CustomNames;
 import org.bukkit.Location;
 import org.bukkit.block.CreatureSpawner;
 import org.bukkit.entity.Entity;
@@ -63,21 +63,20 @@ public final class SpawnersProvider_Default implements SpawnersProvider {
         } catch (Throwable ignored) {
         }
 
-        String customName = plugin.getSettings().spawnerItemName;
-
-        if (!customName.equals("")) {
+        String customName = plugin.getSettings().spawnersItemName;
+        if (!customName.isEmpty()) {
             itemMeta.setDisplayName(customName.replace("{0}", perStackAmount + "")
-                    .replace("{1}", EntityUtils.getFormattedType(entityType.name()))
+                    .replace("{1}", CustomNames.getSpawnerCustomName(entityType))
                     .replace("{2}", spawnerUpgrade == null ? "" : spawnerUpgrade.getDisplayName()));
         }
 
-        List<String> customLore = plugin.getSettings().spawnerItemLore;
-
+        List<String> customLore = plugin.getSettings().spawnersItemLore;
         if (!customLore.isEmpty()) {
             List<String> lore = new ArrayList<>();
             for (String line : customLore)
                 lore.add(line.replace("{0}", perStackAmount + "")
-                        .replace("{1}", EntityUtils.getFormattedType(entityType.name())));
+                        .replace("{1}", CustomNames.getSpawnerCustomName(entityType))
+                        .replace("{2}", spawnerUpgrade == null ? "" : spawnerUpgrade.getDisplayName()));
             itemMeta.setLore(lore);
         }
 

--- a/src/main/java/com/bgsoftware/wildstacker/listeners/BarrelsListener.java
+++ b/src/main/java/com/bgsoftware/wildstacker/listeners/BarrelsListener.java
@@ -11,6 +11,7 @@ import com.bgsoftware.wildstacker.utils.ServerVersion;
 import com.bgsoftware.wildstacker.utils.entity.EntityUtils;
 import com.bgsoftware.wildstacker.utils.events.EventsCaller;
 import com.bgsoftware.wildstacker.utils.items.ItemUtils;
+import com.bgsoftware.wildstacker.utils.names.CustomNames;
 import com.bgsoftware.wildstacker.utils.threads.Executor;
 import org.bukkit.Chunk;
 import org.bukkit.GameMode;
@@ -122,7 +123,7 @@ public final class BarrelsListener implements Listener {
 
             if (!blockOptional.isPresent()) {
                 if (isChunkLimit(chunk)) {
-                    Locale.CHUNK_LIMIT_EXCEEDED.send(e.getPlayer(), ItemUtils.getFormattedType(stackedBarrel.getBarrelItem(1)) + " Barrels");
+                    Locale.BARREL_CHUNK_LIMIT_EXCEEDED.send(e.getPlayer(), CustomNames.getBarrelCustomName(stackedBarrel.getBarrelItem(1)));
                     stackedBarrel.remove();
                     return;
                 }
@@ -148,7 +149,7 @@ public final class BarrelsListener implements Listener {
 
                         stackedBarrel.updateName();
 
-                        Locale.BARREL_PLACE.send(e.getPlayer(), ItemUtils.getFormattedType(stackedBarrel.getBarrelItem(1)));
+                        Locale.BARREL_PLACE.send(e.getPlayer(), CustomNames.getBarrelCustomName(stackedBarrel.getBarrelItem(1)));
 
                         finishBarrelPlace(e.getPlayer(), usedHand, stackedBarrel, REPLACE_AIR);
                     }
@@ -159,13 +160,13 @@ public final class BarrelsListener implements Listener {
 
                 stackedBarrel.updateName();
 
-                Locale.BARREL_PLACE.send(e.getPlayer(), ItemUtils.getFormattedType(stackedBarrel.getBarrelItem(1)));
+                Locale.BARREL_PLACE.send(e.getPlayer(), CustomNames.getBarrelCustomName(stackedBarrel.getBarrelItem(1)));
             } else {
                 if (e.getPlayer().getGameMode() != GameMode.CREATIVE)
                     ItemUtils.removeItemFromHand(e.getPlayer(), 1, usedHand);
 
                 StackedBarrel targetBarrel = WStackedBarrel.of(blockOptional.get());
-                Locale.BARREL_UPDATE.send(e.getPlayer(), ItemUtils.getFormattedType(targetBarrel.getBarrelItem(1)), targetBarrel.getStackAmount());
+                Locale.BARREL_UPDATE.send(e.getPlayer(), CustomNames.getBarrelCustomName(targetBarrel.getBarrelItem(1)), targetBarrel.getStackAmount());
             }
 
             finishBarrelPlace(e.getPlayer(), usedHand, stackedBarrel, REPLACE_AIR);
@@ -215,7 +216,7 @@ public final class BarrelsListener implements Listener {
 
             e.getBlock().setType(Material.AIR);
 
-            Locale.BARREL_BREAK.send(e.getPlayer(), stackSize, ItemUtils.getFormattedType(stackedBarrel.getBarrelItem(1)));
+            Locale.BARREL_BREAK.send(e.getPlayer(), stackSize, CustomNames.getBarrelCustomName(stackedBarrel.getBarrelItem(1)));
         }
     }
 

--- a/src/main/java/com/bgsoftware/wildstacker/listeners/SpawnersListener.java
+++ b/src/main/java/com/bgsoftware/wildstacker/listeners/SpawnersListener.java
@@ -24,6 +24,7 @@ import com.bgsoftware.wildstacker.utils.events.EventsCaller;
 import com.bgsoftware.wildstacker.utils.items.ItemUtils;
 import com.bgsoftware.wildstacker.utils.legacy.EntityTypes;
 import com.bgsoftware.wildstacker.utils.legacy.Materials;
+import com.bgsoftware.wildstacker.utils.names.CustomNames;
 import com.bgsoftware.wildstacker.utils.pair.Pair;
 import com.bgsoftware.wildstacker.utils.spawners.SpawnerCachedData;
 import com.bgsoftware.wildstacker.utils.threads.Executor;
@@ -126,7 +127,7 @@ public final class SpawnersListener implements Listener {
             if (amountToCharge > 0)
                 plugin.getProviders().getEconomyProvider().withdrawMoney(player, amountToCharge);
 
-            Locale.SPAWNER_BREAK.send(player, EntityUtils.getFormattedType(entityType.name()), breakAmount, GeneralUtils.format(amountToCharge));
+            Locale.SPAWNER_BREAK.send(player, CustomNames.getSpawnerCustomName(entityType), breakAmount, GeneralUtils.format(amountToCharge));
 
             return true;
         }
@@ -235,7 +236,7 @@ public final class SpawnersListener implements Listener {
             if (!spawnerOptional.isPresent()) {
                 if (isChunkLimit(chunk, spawnerType)) {
                     e.setCancelled(true);
-                    Locale.CHUNK_LIMIT_EXCEEDED.send(e.getPlayer(), EntityUtils.getFormattedType(stackedSpawner.getSpawnedType().name()) + " Spawners");
+                    Locale.SPAWNER_CHUNK_LIMIT_EXCEEDED.send(e.getPlayer(), CustomNames.getSpawnerCustomName(stackedSpawner.getSpawnedType()));
                     stackedSpawner.remove();
                     return;
                 }
@@ -322,7 +323,7 @@ public final class SpawnersListener implements Listener {
         if (limitItem != null)
             ItemUtils.addItem(limitItem, player.getInventory(), player.getLocation());
 
-        Locale.SPAWNER_PLACE.send(player, EntityUtils.getFormattedType(spawnerType.name()), spawnerItemAmount, GeneralUtils.format(amountToCharge));
+        Locale.SPAWNER_PLACE.send(player, CustomNames.getSpawnerCustomName(spawnerType), spawnerItemAmount, GeneralUtils.format(amountToCharge));
 
         alreadySpawnersPlacedPlayers.remove(player.getUniqueId());
     }
@@ -645,7 +646,7 @@ public final class SpawnersListener implements Listener {
                 return;
 
             ((WStackedSpawner) stackedSpawner).setCachedDisplayName(
-                    EntityUtils.getFormattedType(stackedSpawner.getSpawnedType().name()));
+                    CustomNames.getSpawnerCustomName(stackedSpawner.getSpawnedType()));
 
             customName = plugin.getSettings().spawnersNameBuilder.build(stackedSpawner);
             ((WStackedSpawner) stackedSpawner).setHologramName(customName, true);

--- a/src/main/java/com/bgsoftware/wildstacker/listeners/ToolsListener.java
+++ b/src/main/java/com/bgsoftware/wildstacker/listeners/ToolsListener.java
@@ -12,6 +12,7 @@ import com.bgsoftware.wildstacker.objects.WStackedEntity;
 import com.bgsoftware.wildstacker.objects.WStackedSpawner;
 import com.bgsoftware.wildstacker.utils.entity.EntityUtils;
 import com.bgsoftware.wildstacker.utils.items.ItemUtils;
+import com.bgsoftware.wildstacker.utils.names.CustomNames;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -47,7 +48,7 @@ public final class ToolsListener implements Listener {
 
         Locale.ENTITY_INFO_HEADER.send(e.getPlayer());
         Locale.ENTITY_INFO_UUID.send(e.getPlayer(), stackedEntity.getUniqueId());
-        Locale.ENTITY_INFO_TYPE.send(e.getPlayer(), EntityUtils.getFormattedType(stackedEntity.getType().name()));
+        Locale.ENTITY_INFO_TYPE.send(e.getPlayer(), CustomNames.getEntityCustomName(stackedEntity.getType()));
         Locale.ENTITY_INFO_AMOUNT.send(e.getPlayer(), stackedEntity.getStackAmount());
         Locale.ENTITY_INFO_SPAWN_REASON.send(e.getPlayer(), stackedEntity.getSpawnCause().name());
         Locale.ENTITY_INFO_NERFED.send(e.getPlayer(), stackedEntity.isNerfed() ? "True" : "False");
@@ -66,7 +67,7 @@ public final class ToolsListener implements Listener {
         StackedBarrel stackedBarrel = WStackedBarrel.of(e.getClickedBlock());
 
         Locale.BARREL_INFO_HEADER.send(e.getPlayer());
-        Locale.BARREL_INFO_TYPE.send(e.getPlayer(), ItemUtils.getFormattedType(stackedBarrel.getBarrelItem(1)));
+        Locale.BARREL_INFO_TYPE.send(e.getPlayer(), CustomNames.getBarrelCustomName(stackedBarrel.getBarrelItem(1)));
         Locale.BARREL_INFO_AMOUNT.send(e.getPlayer(), stackedBarrel.getStackAmount());
         Locale.BARREL_INFO_FOOTER.send(e.getPlayer());
     }
@@ -82,7 +83,7 @@ public final class ToolsListener implements Listener {
         StackedSpawner stackedSpawner = WStackedSpawner.of(e.getClickedBlock());
 
         Locale.SPAWNER_INFO_HEADER.send(e.getPlayer());
-        Locale.SPAWNER_INFO_TYPE.send(e.getPlayer(), EntityUtils.getFormattedType(stackedSpawner.getSpawnedType().name()));
+        Locale.SPAWNER_INFO_TYPE.send(e.getPlayer(), CustomNames.getSpawnerCustomName(stackedSpawner.getSpawnedType()));
         Locale.SPAWNER_INFO_AMOUNT.send(e.getPlayer(), stackedSpawner.getStackAmount());
         Locale.SPAWNER_INFO_UPGRADE.send(e.getPlayer(), stackedSpawner.getUpgrade().getName());
         Locale.SPAWNER_INFO_FOOTER.send(e.getPlayer());

--- a/src/main/java/com/bgsoftware/wildstacker/menu/BarrelsPlaceMenu.java
+++ b/src/main/java/com/bgsoftware/wildstacker/menu/BarrelsPlaceMenu.java
@@ -7,6 +7,7 @@ import com.bgsoftware.wildstacker.utils.ServerVersion;
 import com.bgsoftware.wildstacker.utils.entity.EntityUtils;
 import com.bgsoftware.wildstacker.utils.events.EventsCaller;
 import com.bgsoftware.wildstacker.utils.items.ItemUtils;
+import com.bgsoftware.wildstacker.utils.names.CustomNames;
 import com.bgsoftware.wildstacker.utils.threads.Executor;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -29,7 +30,7 @@ public final class BarrelsPlaceMenu extends WildMenu {
         super("barrelsPlace");
         this.location = location;
         this.inventory = Bukkit.createInventory(this, 9 * 4, plugin.getSettings().barrelsPlaceInventoryTitle
-                .replace("{0}", EntityUtils.getFormattedType(barrelItem.getType().name())));
+                .replace("{0}", CustomNames.getBarrelCustomName(barrelItem)));
         this.barrelItem = barrelItem;
         this.cancelOnClick = false;
     }
@@ -136,7 +137,7 @@ public final class BarrelsPlaceMenu extends WildMenu {
 
             if (EventsCaller.callBarrelPlaceInventoryEvent((Player) e.getPlayer(), stackedBarrel, increaseStackAmount)) {
                 int newStackAmount = stackedBarrel.increaseStackAmount(increaseStackAmount, true);
-                Locale.BARREL_UPDATE.send(e.getPlayer(), ItemUtils.getFormattedType(barrelItem), newStackAmount);
+                Locale.BARREL_UPDATE.send(e.getPlayer(), CustomNames.getBarrelCustomName(barrelItem), newStackAmount);
             } else {
                 ItemUtils.addItems(e.getInventory().getContents(), e.getPlayer().getInventory(), stackedBarrel.getLocation());
             }

--- a/src/main/java/com/bgsoftware/wildstacker/menu/ConfigSectionEditorMenu.java
+++ b/src/main/java/com/bgsoftware/wildstacker/menu/ConfigSectionEditorMenu.java
@@ -1,8 +1,8 @@
 package com.bgsoftware.wildstacker.menu;
 
-import com.bgsoftware.wildstacker.utils.entity.EntityUtils;
 import com.bgsoftware.wildstacker.utils.items.ItemBuilder;
 import com.bgsoftware.wildstacker.utils.legacy.Materials;
+import com.bgsoftware.wildstacker.utils.names.CustomNames;
 import com.bgsoftware.wildstacker.utils.threads.Executor;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -186,7 +186,7 @@ public final class ConfigSectionEditorMenu extends WildMenu {
                 continue;
 
             ItemBuilder itemBuilder = new ItemBuilder(Materials.CLOCK.toBukkitItem()).withName("&6" +
-                    EntityUtils.format(path.replace("-", "_")
+                    CustomNames.format(path.replace("-", "_")
                             .replace(".", "_").replace(" ", "_")));
 
             if (section.isBoolean(path))

--- a/src/main/java/com/bgsoftware/wildstacker/objects/WStackedBarrel.java
+++ b/src/main/java/com/bgsoftware/wildstacker/objects/WStackedBarrel.java
@@ -11,6 +11,7 @@ import com.bgsoftware.wildstacker.utils.GeneralUtils;
 import com.bgsoftware.wildstacker.utils.ServerVersion;
 import com.bgsoftware.wildstacker.utils.events.EventsCaller;
 import com.bgsoftware.wildstacker.utils.items.ItemUtils;
+import com.bgsoftware.wildstacker.utils.names.CustomNames;
 import com.bgsoftware.wildstacker.utils.particles.ParticleWrapper;
 import com.bgsoftware.wildstacker.utils.threads.Executor;
 import com.bgsoftware.wildstacker.utils.threads.StackService;
@@ -46,7 +47,7 @@ public final class WStackedBarrel extends WStackedHologramObject<Block> implemen
     public WStackedBarrel(Block block, ItemStack itemStack, int stackAmount) {
         super(block, stackAmount);
         this.barrelItem = itemStack;
-        setCachedDisplayName(ItemUtils.getFormattedType(barrelItem));
+        setCachedDisplayName(CustomNames.getBarrelCustomName(barrelItem));
     }
 
     public static StackedBarrel of(Block block) {
@@ -123,11 +124,16 @@ public final class WStackedBarrel extends WStackedHologramObject<Block> implemen
             itemStack.setAmount(1);
 
             ItemMeta itemMeta = itemStack.getItemMeta();
-            itemMeta.setDisplayName(WildStackerPlugin.getPlugin().getSettings().giveItemName
-                    .replace("{0}", amount + "")
-                    .replace("{1}", ItemUtils.getFormattedType(new ItemStack(getType())))
-                    .replace("{2}", "Barrel")
+            String barrelName = CustomNames.getBarrelCustomName(new ItemStack(getType()));
+
+            itemMeta.setDisplayName(WildStackerPlugin.getPlugin().getSettings().barrelsItemName
+                    .replace("{0}", amount + "").replace("{1}", barrelName)
             );
+
+            List<String> lore = new ArrayList<>();
+            for (String line : plugin.getSettings().barrelsItemLore)
+                lore.add(line.replace("{0}", amount + "").replace("{1}", barrelName));
+            itemMeta.setLore(lore);
 
             itemStack.setItemMeta(itemMeta);
         } else {

--- a/src/main/java/com/bgsoftware/wildstacker/objects/WStackedEntity.java
+++ b/src/main/java/com/bgsoftware/wildstacker/objects/WStackedEntity.java
@@ -21,6 +21,7 @@ import com.bgsoftware.wildstacker.utils.items.ItemStackList;
 import com.bgsoftware.wildstacker.utils.items.ItemUtils;
 import com.bgsoftware.wildstacker.utils.legacy.EntityTypes;
 import com.bgsoftware.wildstacker.utils.legacy.Materials;
+import com.bgsoftware.wildstacker.utils.names.CustomNames;
 import com.bgsoftware.wildstacker.utils.pair.Pair;
 import com.bgsoftware.wildstacker.utils.particles.ParticleWrapper;
 import com.bgsoftware.wildstacker.utils.threads.Executor;
@@ -69,7 +70,7 @@ public final class WStackedEntity extends WAsyncStackedObject<LivingEntity> impl
         this.spawnCause = getAndRemoveFlag(EntityFlag.SPAWN_CAUSE);
         if (this.spawnCause == null)
             this.spawnCause = plugin.getNMSEntities().getEntitySpawnCause(livingEntity);
-        setCachedDisplayName(EntityUtils.getFormattedType(getType().name()));
+        setCachedDisplayName(CustomNames.getEntityCustomName(getType()));
     }
 
     public static StackedEntity of(Entity entity) {

--- a/src/main/java/com/bgsoftware/wildstacker/objects/WStackedItem.java
+++ b/src/main/java/com/bgsoftware/wildstacker/objects/WStackedItem.java
@@ -12,6 +12,7 @@ import com.bgsoftware.wildstacker.utils.entity.EntityStorage;
 import com.bgsoftware.wildstacker.utils.events.EventsCaller;
 import com.bgsoftware.wildstacker.utils.items.ItemUtils;
 import com.bgsoftware.wildstacker.utils.legacy.Materials;
+import com.bgsoftware.wildstacker.utils.names.CustomNames;
 import com.bgsoftware.wildstacker.utils.particles.ParticleWrapper;
 import com.bgsoftware.wildstacker.utils.threads.Executor;
 import com.bgsoftware.wildstacker.utils.threads.StackService;
@@ -169,7 +170,7 @@ public final class WStackedItem extends WAsyncStackedObject<Item> implements Sta
         boolean updateName = (mmoItem && mmoItemName != null) || plugin.getSettings().itemsUnstackedCustomName || amount > 1;
 
         if (updateName) {
-            String cachedDisplayName = mmoItem && mmoItemName != null ? mmoItemName : ItemUtils.getFormattedType(itemStack);
+            String cachedDisplayName = mmoItem && mmoItemName != null ? mmoItemName : CustomNames.getItemCustomName(itemStack);
             String displayName = itemStack.hasItemMeta() && itemStack.getItemMeta().hasDisplayName() ? itemStack.getItemMeta().getDisplayName() : cachedDisplayName;
 
             if (plugin.getSettings().itemsDisplayEnabled)

--- a/src/main/java/com/bgsoftware/wildstacker/objects/WStackedSpawner.java
+++ b/src/main/java/com/bgsoftware/wildstacker/objects/WStackedSpawner.java
@@ -8,8 +8,8 @@ import com.bgsoftware.wildstacker.api.objects.StackedSpawner;
 import com.bgsoftware.wildstacker.api.upgrades.SpawnerUpgrade;
 import com.bgsoftware.wildstacker.menu.SpawnersManageMenu;
 import com.bgsoftware.wildstacker.utils.GeneralUtils;
-import com.bgsoftware.wildstacker.utils.entity.EntityUtils;
 import com.bgsoftware.wildstacker.utils.events.EventsCaller;
+import com.bgsoftware.wildstacker.utils.names.CustomNames;
 import com.bgsoftware.wildstacker.utils.particles.ParticleWrapper;
 import com.bgsoftware.wildstacker.utils.spawners.SyncedCreatureSpawner;
 import com.bgsoftware.wildstacker.utils.threads.Executor;
@@ -204,7 +204,7 @@ public final class WStackedSpawner extends WStackedHologramObject<CreatureSpawne
             return;
         }
 
-        setCachedDisplayName(EntityUtils.getFormattedType(getSpawnedType().name()));
+        setCachedDisplayName(CustomNames.getSpawnerCustomName(getSpawnedType()));
         customName = plugin.getSettings().spawnersNameBuilder.build(this);
         setHologramName(customName, !plugin.getSettings().floatingSpawnerNames);
     }

--- a/src/main/java/com/bgsoftware/wildstacker/utils/entity/EntityUtils.java
+++ b/src/main/java/com/bgsoftware/wildstacker/utils/entity/EntityUtils.java
@@ -11,7 +11,6 @@ import com.bgsoftware.wildstacker.utils.ServerVersion;
 import com.bgsoftware.wildstacker.utils.legacy.EntityTypes;
 import com.bgsoftware.wildstacker.utils.threads.Executor;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
@@ -97,27 +96,6 @@ public final class EntityUtils {
     private static final EntityType MANNEQUIN = getEntityTypeSafe("MANNEQUIN");
     @Nullable
     private static final PotionEffectType BAD_OMEN = PotionEffectType.getByName("BAD_OMEN");
-
-    public static String getFormattedType(String typeName) {
-        if (typeName.contains(String.valueOf(ChatColor.COLOR_CHAR)))
-            return typeName;
-
-        String customName = plugin.getSettings().customNames.get(typeName);
-        if (customName != null)
-            return customName;
-
-        return format(typeName);
-    }
-
-    public static String format(String type) {
-        StringBuilder name = new StringBuilder();
-
-        for (String section : type.split("_")) {
-            name.append(section.substring(0, 1).toUpperCase()).append(section.substring(1).toLowerCase()).append(" ");
-        }
-
-        return name.substring(0, name.length() - 1);
-    }
 
     public static boolean isNameBlacklisted(String name) {
         if (name == null)

--- a/src/main/java/com/bgsoftware/wildstacker/utils/items/ItemUtils.java
+++ b/src/main/java/com/bgsoftware/wildstacker/utils/items/ItemUtils.java
@@ -4,9 +4,9 @@ import com.bgsoftware.common.reflection.ReflectMethod;
 import com.bgsoftware.wildstacker.WildStackerPlugin;
 import com.bgsoftware.wildstacker.api.upgrades.SpawnerUpgrade;
 import com.bgsoftware.wildstacker.utils.ServerVersion;
-import com.bgsoftware.wildstacker.utils.entity.EntityUtils;
 import com.bgsoftware.wildstacker.utils.legacy.EntityTypes;
 import com.bgsoftware.wildstacker.utils.legacy.Materials;
+import com.bgsoftware.wildstacker.utils.names.CustomNames;
 import com.bgsoftware.wildstacker.utils.threads.Executor;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -27,11 +27,14 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SpawnEggMeta;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
@@ -118,6 +121,77 @@ public final class ItemUtils {
         }
     }
 
+    public static ItemStack getEggItem(EntityType entityType, int amount, @Nullable SpawnerUpgrade spawnerUpgrade) {
+        ItemStack itemStack;
+
+        Material eggType = Materials.getSpawnEgg(entityType);
+        if (eggType == null || ServerVersion.isLegacy()) {
+            if (ServerVersion.isLegacy()) {
+                itemStack = new ItemStack(Material.MONSTER_EGG);
+                setEntityType(itemStack, entityType);
+            } else {
+                itemStack = getItemNMSEntityType(entityType);
+            }
+        } else {
+            itemStack = new ItemStack(eggType);
+        }
+
+        itemStack = setSpawnerItemAmount(itemStack, amount);
+
+        if (spawnerUpgrade != null && !spawnerUpgrade.isDefault())
+            itemStack = setSpawnerUpgrade(itemStack, spawnerUpgrade.getId());
+
+        ItemMeta itemMeta = itemStack.getItemMeta();
+        String eggName = CustomNames.getEggCustomName(entityType);
+        String upgradeName = spawnerUpgrade == null ? "" : spawnerUpgrade.getDisplayName();
+
+        String customName = plugin.getSettings().eggsItemName;
+        if (!customName.isEmpty()) {
+            itemMeta.setDisplayName(customName.replace("{0}", amount + "")
+                    .replace("{1}", eggName).replace("{2}", upgradeName));
+        }
+
+        List<String> customLore = plugin.getSettings().eggsItemLore;
+        if (!customLore.isEmpty()) {
+            List<String> lore = new ArrayList<>();
+            for (String line : customLore)
+                lore.add(line.replace("{0}", amount + "")
+                        .replace("{1}", eggName).replace("{2}", upgradeName));
+            itemMeta.setLore(lore);
+        }
+
+        itemStack.setItemMeta(itemMeta);
+
+        return itemStack;
+    }
+
+    public static ItemStack getBarrelItem(Material material, int amount) {
+        ItemStack itemStack = new ItemStack(material);
+
+        itemStack = setSpawnerItemAmount(itemStack, amount);
+
+        ItemMeta itemMeta = itemStack.getItemMeta();
+        String barrelName = CustomNames.getBarrelCustomName(itemStack);
+
+        String customName = plugin.getSettings().barrelsItemName;
+        if (!customName.isEmpty()) {
+            itemMeta.setDisplayName(customName.replace("{0}", amount + "")
+                    .replace("{1}", barrelName));
+        }
+
+        List<String> customLore = plugin.getSettings().barrelsItemLore;
+        if (!customLore.isEmpty()) {
+            List<String> lore = new ArrayList<>();
+            for (String line : customLore)
+                lore.add(line.replace("{0}", amount + "").replace("{1}", barrelName));
+            itemMeta.setLore(lore);
+        }
+
+        itemStack.setItemMeta(itemMeta);
+
+        return itemStack;
+    }
+
     public static ItemStack setSpawnerItemAmount(ItemStack itemStack, int amount) {
         return plugin.getNMSAdapter().setTag(itemStack, "spawners-amount", amount);
     }
@@ -187,20 +261,6 @@ public final class ItemUtils {
     public static EntityType getNMSEntityType(ItemStack itemStack) {
         String entityType = plugin.getNMSAdapter().getTag(itemStack, "entity-type", String.class, "");
         return entityType.isEmpty() ? null : EntityType.valueOf(entityType);
-    }
-
-    public static String getFormattedType(ItemStack itemStack) {
-        String typeName = LEGACY_PATTERN.matcher(itemStack.getType().name()).replaceAll("");
-
-        String customName = plugin.getSettings().customNames.get(typeName);
-        if (customName != null)
-            return customName;
-
-        customName = plugin.getSettings().customNames.get(typeName + ":" + itemStack.getDurability());
-        if (customName != null)
-            return customName;
-
-        return EntityUtils.getFormattedType(typeName);
     }
 
     public static void stackBucket(ItemStack bucket, Inventory inventory) {

--- a/src/main/java/com/bgsoftware/wildstacker/utils/names/CustomNames.java
+++ b/src/main/java/com/bgsoftware/wildstacker/utils/names/CustomNames.java
@@ -1,0 +1,122 @@
+package com.bgsoftware.wildstacker.utils.names;
+
+import com.bgsoftware.wildstacker.WildStackerPlugin;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.EntityType;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.regex.Pattern;
+
+public class CustomNames {
+
+    private static final Pattern LEGACY_PATTERN = Pattern.compile("LEGACY_");
+
+    private static final WildStackerPlugin plugin = WildStackerPlugin.getPlugin();
+
+    public static String getEggCustomName(EntityType entityType) {
+        String typeName = entityType.name();
+
+        if (typeName.contains(String.valueOf(ChatColor.COLOR_CHAR)))
+            return typeName;
+
+        String customName = plugin.getSettings().eggsCustomNames.get(typeName);
+
+        if (customName != null)
+            return customName;
+
+        return getGlobalCustomName(typeName);
+    }
+
+    public static String getItemCustomName(ItemStack itemStack) {
+        String typeName = LEGACY_PATTERN.matcher(itemStack.getType().name()).replaceAll("");
+
+        String customName = plugin.getSettings().itemsCustomNames.get(typeName);
+
+        if (customName != null)
+            return customName;
+
+        customName = plugin.getSettings().itemsCustomNames.get(typeName + ":" + itemStack.getDurability());
+
+        if (customName != null)
+            return customName;
+
+        return getGlobalCustomName(typeName, itemStack);
+    }
+
+    public static String getEntityCustomName(EntityType entityType) {
+        String typeName = entityType.name();
+
+        if (typeName.contains(String.valueOf(ChatColor.COLOR_CHAR)))
+            return typeName;
+
+        String customName = plugin.getSettings().entitiesCustomNames.get(typeName);
+
+        if (customName != null)
+            return customName;
+
+        return getGlobalCustomName(typeName);
+    }
+
+    public static String getSpawnerCustomName(EntityType entityType) {
+        String typeName = entityType.name();
+
+        if (typeName.contains(String.valueOf(ChatColor.COLOR_CHAR)))
+            return typeName;
+
+        String customName = plugin.getSettings().spawnersCustomNames.get(typeName);
+
+        if (customName != null)
+            return customName;
+
+        return getGlobalCustomName(typeName);
+    }
+
+    public static String getBarrelCustomName(ItemStack itemStack) {
+        String typeName = LEGACY_PATTERN.matcher(itemStack.getType().name()).replaceAll("");
+
+        String customName = plugin.getSettings().barrelsCustomNames.get(typeName);
+
+        if (customName != null)
+            return customName;
+
+        customName = plugin.getSettings().barrelsCustomNames.get(typeName + ":" + itemStack.getDurability());
+
+        if (customName != null)
+            return customName;
+
+        return getGlobalCustomName(typeName, itemStack);
+    }
+
+    private static String getGlobalCustomName(String typeName) {
+        String customName = plugin.getSettings().globalCustomNames.get(typeName);
+
+        if (customName != null)
+            return customName;
+
+        return format(typeName);
+    }
+
+    private static String getGlobalCustomName(String typeName, ItemStack itemStack) {
+        String customName = plugin.getSettings().globalCustomNames.get(typeName);
+
+        if (customName != null)
+            return customName;
+
+        customName = plugin.getSettings().globalCustomNames.get(typeName + ":" + itemStack.getDurability());
+
+        if (customName != null)
+            return customName;
+
+        return format(typeName);
+    }
+
+    public static String format(String type) {
+        StringBuilder name = new StringBuilder();
+
+        for (String section : type.split("_"))
+            name.append(section.substring(0, 1).toUpperCase()).append(section.substring(1).toLowerCase()).append(" ");
+
+        return name.substring(0, name.length() - 1);
+    }
+
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,12 +5,6 @@
 ##                                           ##
 ###############################################
 
-# How should the item that is given to players by the give command be called?
-# {0} represents stack size
-# {1} represents entity/block type
-# {2} represents item type (Egg / Spawner / Barrel)
-give-item-name: '&6x{0} &f&o{1} {2}'
-
 # The inspect tool of the plugin.
 # When clicking an item, entity, barrel or spawner, all the information
 # about the object will be displayed to the player.
@@ -98,6 +92,24 @@ kill-task:
     # A list of worlds that items will be cleared inside.
     # If you want all worlds, set this to []
     worlds: []
+
+# Here you can configurable all features related to stacked eggs.
+eggs:
+  # All settings related to the egg items.
+  egg-item:
+    # Custom name for the item.
+    # If you don't want a custom name, use "name: ''"
+    # {0} represents stack amount
+    # {1} represents entity type
+    # {2} represents the upgrade's display name
+    name: '&6x{0} &f&o{1} Egg{2}'
+
+    # Custom lore for the item.
+    # If you don't want a custom lore, use "lore: []"
+    # {0} represents stack amount
+    # {1} represents entity type
+    # {2} represents the upgrade's display name
+    lore: [ ]
 
 # Here you can configurable all features related to stacked items.
 items:
@@ -556,17 +568,18 @@ spawners:
   # All settings related to the spawner items.
   spawner-item:
     # Custom name for the item.
-    # If you don't want a custom name, use "custom-name: ''"
+    # If you don't want a custom name, use "name: ''"
     # {0} represents stack amount
     # {1} represents entity type
     # {2} represents the upgrade's display name
-    name: '&6x{0} &f&o{1} Spawners{2}'
+    name: '&6x{0} &f&o{1} Spawner{2}'
 
     # Custom lore for the item.
-    # If you don't want a custom lore, use "custom-lore: []"
+    # If you don't want a custom lore, use "lore: []"
     # {0} represents stack amount
     # {1} represents entity type
-    lore: []
+    # {2} represents the upgrade's display name
+    lore: [ ]
 
   # Here you can configurable all features related to silk-touch enchantment.
   # Other spawner plugins, such as SilkSpawners and MineableSpawners, will override this section.
@@ -863,6 +876,20 @@ barrels:
   # of only in the provided radius. merge-radius will be overridden, and will be used
   # as a y-level range only.
   chunk-merge: false
+
+  # All settings related to the barrel items.
+  barrel-item:
+    # Custom name for the item.
+    # If you don't want a custom name, use "name: ''"
+    # {0} represents stack amount
+    # {1} represents material
+    name: '&6x{0} &f&o{1} Barrel'
+
+    # Custom lore for the item.
+    # If you don't want a custom lore, use "lore: []"
+    # {0} represents stack amount
+    # {1} represents material
+    lore: [ ]
 
   # Should explosions break the entire stack, or just reducing it by one?
   explosions-break-stack: true

--- a/src/main/resources/custom-names.yml
+++ b/src/main/resources/custom-names.yml
@@ -8,10 +8,30 @@
 # Should this feature be enabled?
 enabled: true
 
-# Here you can specify custom types for entities & items.
-# Please follow the "ITEM_TYPE: CUSTOM_NAME", "'ITEM_TYPE:ITEM_DATA': CUSTOM_NAME" and "ENTITY_TYPE: CUSTOM_NAME" formats.
-# {0} represents item's name, if found
+# Global translations applied to all categories unless specifically overridden below.
+# Make sure you follow the "MATERIAL: CUSTOM_NAME", "'MATERIAL:DATA': CUSTOM_NAME"
+# and "ENTITY_TYPE: CUSTOM_NAME" formats. {0} represents item's name, if found.
+global:
+  'INK_SACK:15': 'Bone Meal'
+  MOB_SPAWNER: '{0}'
+  PIG: 'Piggy'
 
-'INK_SACK:15': 'Bone Meal'
-MOB_SPAWNER: '{0}'
-PIG: 'Piggy'
+# Translations used by stacked eggs.
+# Make sure you follow the "ENTITY_TYPE: CUSTOM_NAME" format.
+eggs: { }
+
+# Translations used by stacked items.
+# Make sure you follow the "MATERIAL: CUSTOM_NAME" and "'MATERIAL:DATA': CUSTOM_NAME" formats.
+items: { }
+
+# Translations used by stacked entities.
+# Make sure you follow the "ENTITY_TYPE: CUSTOM_NAME" format.
+entities: { }
+
+# Translations used by stacked spawners.
+# Make sure you follow the "ENTITY_TYPE: CUSTOM_NAME" format.
+spawners: { }
+
+# Translations used by stacked barrels.
+# Make sure you follow the "MATERIAL: CUSTOM_NAME" and "'MATERIAL:DATA': CUSTOM_NAME" formats.
+barrels: { }

--- a/src/main/resources/lang.yml
+++ b/src/main/resources/lang.yml
@@ -18,7 +18,7 @@ BARREL_TOGGLE_OFF: '&6&lWildStacker &7Barrels placement has been disabled.'
 BARREL_NO_PERMISSION: '&6&lWildStacker &7You don''t have permission to use barrels.'
 
 # Called when the chunk limit is exceeded.
-CHUNK_LIMIT_EXCEEDED: '&6&lWildStacker &7You exceeded the chunk limit of {0} for this chunk.'
+BARREL_CHUNK_LIMIT_EXCEEDED: '&6&lWildStacker &7You exceeded the chunk limit of {0} Barrel for this chunk.'
 
 # Called when a player runs a command not in the required usage
 COMMAND_USAGE: '&6&lWildStacker &7Usage: /{0}'
@@ -87,6 +87,9 @@ SPAWNER_CHANGE_NOT_ENOUGH_ITEMS: '&6&lWildStacker &7You don''t have enough spawn
 # Called when a player attempts to upgrade a spawner.
 SPAWNER_UPGRADE_NOT_ENOUGH_MONEY: '&6&lWildStacker &7You need ${0} in order to upgrade this spawner.'
 SPAWNER_UPGRADE_SUCCESS: '&6&lWildStacker &7Successfully upgraded the spawner!'
+
+# Called when the chunk limit is exceeded.
+SPAWNER_CHUNK_LIMIT_EXCEEDED: '&6&lWildStacker &7You exceeded the chunk limit of {0} Spawner for this chunk.'
 
 # Called when a player successfully runs a give command.
 STACK_GIVE_PLAYER: '&6&lWildStacker &7Successfully gave {0} x{1} {2} {3}.'


### PR DESCRIPTION
# Major change #
- I added the ability to set custom names for specific features, as the current system wasn't suitable for all languages. For example, "Chicken" as an entity is translated differently than "Chicken" as an item (Raw Chicken).
Furthermore, some languages ​​have quite specific variations, so in Polish, for example, "Chicken" as an entity is "Kura," but "Chicken Spawner" is "Spawner Kur," so combining the words "Spawner" and "Kura" as an entity isn't suitable or universal for all languages.

# Other changes #
- I removed the "give-item-name" option. Spawners were already using their own option, so based on it, I added the same one for eggs and barrels, for greater flexibility in modification.
- By introducing the above option, it was now possible to display upgrades in the egg name.
- I added the ability to display upgrades in egg lore and spawner lore, instead of just in the name, as was previously the case.
- Split the CHUNK_LIMIT_EXCEEDED message into BARREL_CHUNK_LIMIT_EXCEEDED and SPAWNER_CHUNK_LIMIT_EXCEEDED, as they added the unmodifiable word "Barrels"/"Spawners" to the message.

@OmerBenGera I hope you like the change. I'd appreciate it if you could take a quick look at it, as I'd also like to work on some other changes 😀.