### PR TITLE
Add option to set item amount in menu

### DIFF
--- a/src/main/java/com/bgsoftware/wildstacker/utils/files/FileUtils.java
+++ b/src/main/java/com/bgsoftware/wildstacker/utils/files/FileUtils.java
@@ -15,10 +15,7 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public final class FileUtils {
 
@@ -63,49 +60,61 @@ public final class FileUtils {
     }
 
     public static ItemBuilder getItemStack(String fileName, ConfigurationSection section) {
-        if (section == null || !section.contains("type"))
+        if (section == null || !section.isString("type"))
             return null;
 
+        String materialName = section.getString("type");
         Material type;
         short data;
 
         try {
-            type = Material.valueOf(section.getString("type"));
+            type = Material.valueOf(materialName);
             data = (short) section.getInt("data");
-        } catch (IllegalArgumentException ex) {
-            WildStackerPlugin.log("&c[" + fileName + "] Couldn't convert " + section.getCurrentPath() + " into an itemstack. Check type & data sections!");
+        } catch (IllegalArgumentException e) {
+            WildStackerPlugin.log("&c[" + fileName + "] Couldn't convert '" + materialName +
+                    "' into an material in '" + section.getCurrentPath() + ".type', skipping...");
             return null;
         }
 
         ItemBuilder itemBuilder = new ItemBuilder(type, data);
 
-        if (section.contains("name"))
-            itemBuilder.withName(ChatColor.translateAlternateColorCodes('&', section.getString("name")));
+        if (section.isInt("amount"))
+            itemBuilder.withAmount(section.getInt("amount"));
 
-        if (section.contains("lore"))
+        if (section.isString("name"))
+            itemBuilder.withName(section.getString("name"));
+
+        if (section.isList("lore"))
             itemBuilder.withLore(section.getStringList("lore"));
 
-        if (section.contains("enchants")) {
-            for (String _enchantment : section.getConfigurationSection("enchants").getKeys(false)) {
+        if (section.isConfigurationSection("enchants")) {
+            for (String enchantName : section.getConfigurationSection("enchants").getKeys(false)) {
                 Enchantment enchantment;
 
                 try {
-                    enchantment = Enchantment.getByName(_enchantment);
-                } catch (Exception ex) {
-                    WildStackerPlugin.log("&c[" + fileName + "] Couldn't convert " + section.getCurrentPath() + ".enchants." + _enchantment + " into an enchantment, skipping...");
+                    enchantment = Enchantment.getByName(enchantName);
+                } catch (IllegalArgumentException e) {
+                    WildStackerPlugin.log("&c[" + fileName + "] Couldn't convert '" + enchantName +
+                            "' into an enchantment in '" + section.getCurrentPath() + ".enchants', skipping...");
                     continue;
                 }
 
-                itemBuilder.withEnchant(enchantment, section.getInt("enchants." + _enchantment));
+                itemBuilder.withEnchant(enchantment, section.getInt("enchants." + enchantName));
             }
         }
 
-        if (section.contains("flags")) {
-            for (String flag : section.getStringList("flags"))
-                itemBuilder.withFlags(ItemFlag.valueOf(flag));
+        if (section.isList("flags")) {
+            for (String flagName : section.getStringList("flags")) {
+                try {
+                    itemBuilder.withFlags(ItemFlag.valueOf(flagName));
+                } catch (IllegalArgumentException e) {
+                    WildStackerPlugin.log("&c[" + fileName + "] Couldn't convert '" + flagName +
+                            "' into an item flag in '" + section.getCurrentPath() + ".flags', skipping...");
+                }
+            }
         }
 
-        if (section.contains("skull"))
+        if (section.isString("skull"))
             itemBuilder.asSkullOf(section.getString("skull"));
 
         return itemBuilder;

--- a/src/main/java/com/bgsoftware/wildstacker/utils/files/FileUtils.java
+++ b/src/main/java/com/bgsoftware/wildstacker/utils/files/FileUtils.java
@@ -15,7 +15,10 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public final class FileUtils {
 

--- a/src/main/java/com/bgsoftware/wildstacker/utils/items/ItemBuilder.java
+++ b/src/main/java/com/bgsoftware/wildstacker/utils/items/ItemBuilder.java
@@ -41,6 +41,11 @@ public final class ItemBuilder {
         itemMeta = itemStack.getItemMeta();
     }
 
+    public ItemBuilder withAmount(int amount) {
+        itemStack.setAmount(amount);
+        return this;
+    }
+
     public ItemBuilder withName(String name) {
         itemMeta.setDisplayName(ChatColor.translateAlternateColorCodes('&', name));
         return this;
@@ -145,13 +150,13 @@ public final class ItemBuilder {
         return this;
     }
 
-    public ItemStack build() {
-        return build(1);
+    public ItemStack build(int amount) {
+        itemStack.setAmount(amount);
+        return build();
     }
 
-    public ItemStack build(int amount) {
+    public ItemStack build() {
         itemStack.setItemMeta(itemMeta);
-        itemStack.setAmount(amount);
         return texture == null ? itemStack : plugin.getNMSAdapter().getPlayerSkull(itemStack, texture);
     }
 

--- a/src/main/resources/menus/spawner-amounts.yml
+++ b/src/main/resources/menus/spawner-amounts.yml
@@ -42,10 +42,12 @@ items:
     name: '&aAdd +1'
   '%':
     type: LIME_STAINED_GLASS_PANE
+    amount: 16
     deposit: 16
     name: '&aAdd +16'
   '^':
     type: LIME_STAINED_GLASS_PANE
+    amount: 64
     deposit: 64
     name: '&aAdd +64'
   '*':
@@ -54,9 +56,11 @@ items:
     name: '&cRemove -1'
   '-':
     type: RED_STAINED_GLASS_PANE
+    amount: 16
     withdraw: 16
     name: '&cRemove -16'
   '+':
     type: RED_STAINED_GLASS_PANE
+    amount: 64
     withdraw: 64
     name: '&cRemove -64'

--- a/src/main/resources/menus/spawner-amounts_legacy.yml
+++ b/src/main/resources/menus/spawner-amounts_legacy.yml
@@ -47,11 +47,13 @@ items:
   '%':
     type: STAINED_GLASS_PANE
     data: 5
+    amount: 16
     deposit: 16
     name: '&aAdd +16'
   '^':
     type: STAINED_GLASS_PANE
     data: 5
+    amount: 64
     deposit: 64
     name: '&aAdd +64'
   '*':
@@ -62,10 +64,12 @@ items:
   '-':
     type: STAINED_GLASS_PANE
     data: 14
+    amount: 16
     withdraw: 16
     name: '&cRemove -16'
   '+':
     type: STAINED_GLASS_PANE
     data: 14
+    amount: 64
     withdraw: 64
     name: '&cRemove -64'


### PR DESCRIPTION
- Added the ability to set item amounts in the menu. In the default configuration, I used this in the spawner-amounts menu to show the amount of deposited/withdrawn spawners.
- Changed the check for whether an item's configuration contains a given option from contains() to a function appropriate for the option type.
- Added a catch for incorrectly added flags in the item's configuration.
- Changed the display of item configuration errors in console to be more universal.