### PR TITLE
feat. add new SpawnerRateModifier

### DIFF
--- a/API/src/main/java/com/bgsoftware/wildstacker/api/handlers/SystemManager.java
+++ b/API/src/main/java/com/bgsoftware/wildstacker/api/handlers/SystemManager.java
@@ -12,6 +12,8 @@ import com.bgsoftware.wildstacker.api.objects.StackedSpawner;
 import com.bgsoftware.wildstacker.api.objects.UnloadedStackedBarrel;
 import com.bgsoftware.wildstacker.api.objects.UnloadedStackedSpawner;
 import com.bgsoftware.wildstacker.api.spawning.SpawnCondition;
+import com.bgsoftware.wildstacker.api.spawning.SpawnerRateContext;
+import com.bgsoftware.wildstacker.api.spawning.SpawnerRateModifier;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -432,5 +434,27 @@ public interface SystemManager {
      * @param spawnCondition The spawn condition to register.
      */
     SpawnCondition registerSpawnCondition(SpawnCondition spawnCondition);
+
+    /**
+     * Register a spawner-rate modifier into the system.
+     * If a modifier already exists with the same id, the new one will override the old one.
+     *
+     * @param modifier The modifier to register.
+     */
+    SpawnerRateModifier registerSpawnerRateModifier(SpawnerRateModifier modifier);
+
+    /**
+     * Remove a spawner-rate modifier from the system.
+     *
+     * @param id The id of the modifier to remove.
+     */
+    void unregisterSpawnerRateModifier(String id);
+
+    /**
+     * Get the combined spawner-rate multiplier for the given context.
+     *
+     * @param context The current spawner ticking context.
+     */
+    double getSpawnerRateMultiplier(SpawnerRateContext context);
 
 }

--- a/API/src/main/java/com/bgsoftware/wildstacker/api/spawning/SpawnerRateContext.java
+++ b/API/src/main/java/com/bgsoftware/wildstacker/api/spawning/SpawnerRateContext.java
@@ -1,0 +1,50 @@
+package com.bgsoftware.wildstacker.api.spawning;
+
+import com.bgsoftware.wildstacker.api.objects.StackedSpawner;
+import org.bukkit.Location;
+import org.bukkit.entity.EntityType;
+
+public final class SpawnerRateContext {
+
+    private final StackedSpawner spawner;
+    private final Location location;
+    private final EntityType entityType;
+    private final int stackAmount;
+    private final int baseTickDelay;
+    private final int currentSpawnDelay;
+
+    public SpawnerRateContext(StackedSpawner spawner, Location location, EntityType entityType,
+                              int stackAmount, int baseTickDelay, int currentSpawnDelay) {
+        this.spawner = spawner;
+        this.location = location;
+        this.entityType = entityType;
+        this.stackAmount = stackAmount;
+        this.baseTickDelay = baseTickDelay;
+        this.currentSpawnDelay = currentSpawnDelay;
+    }
+
+    public StackedSpawner getSpawner() {
+        return spawner;
+    }
+
+    public Location getLocation() {
+        return location;
+    }
+
+    public EntityType getEntityType() {
+        return entityType;
+    }
+
+    public int getStackAmount() {
+        return stackAmount;
+    }
+
+    public int getBaseTickDelay() {
+        return baseTickDelay;
+    }
+
+    public int getCurrentSpawnDelay() {
+        return currentSpawnDelay;
+    }
+
+}

--- a/API/src/main/java/com/bgsoftware/wildstacker/api/spawning/SpawnerRateModifier.java
+++ b/API/src/main/java/com/bgsoftware/wildstacker/api/spawning/SpawnerRateModifier.java
@@ -1,0 +1,25 @@
+package com.bgsoftware.wildstacker.api.spawning;
+
+import com.bgsoftware.wildstacker.api.WildStackerAPI;
+
+import java.util.Objects;
+
+public abstract class SpawnerRateModifier {
+
+    private final String id;
+
+    protected SpawnerRateModifier(String id) {
+        this.id = Objects.requireNonNull(id, "id");
+    }
+
+    public static SpawnerRateModifier register(SpawnerRateModifier modifier) {
+        return WildStackerAPI.getWildStacker().getSystemManager().registerSpawnerRateModifier(modifier);
+    }
+
+    public final String getId() {
+        return id;
+    }
+
+    public abstract double getMultiplier(SpawnerRateContext context);
+
+}

--- a/NMS/src/main/templates/spawner/AbstractStackedBaseSpawner.java.template
+++ b/NMS/src/main/templates/spawner/AbstractStackedBaseSpawner.java.template
@@ -8,6 +8,7 @@ import com.bgsoftware.wildstacker.api.enums.StackCheckResult;
 import com.bgsoftware.wildstacker.api.objects.StackedEntity;
 import com.bgsoftware.wildstacker.api.objects.StackedSpawner;
 import com.bgsoftware.wildstacker.api.spawning.SpawnCondition;
+import com.bgsoftware.wildstacker.api.spawning.SpawnerRateContext;
 import com.bgsoftware.wildstacker.objects.WStackedEntity;
 import com.bgsoftware.wildstacker.objects.WStackedSpawner;
 import com.bgsoftware.wildstacker.utils.Debug;
@@ -57,6 +58,7 @@ public abstract class AbstractStackedBaseSpawner extends BaseSpawner {
 
     private int spawnedEntities = 0;
     private int tickDelay = 0;
+    private double spawnerRateRemainder = 0.0D;
     private WStackedEntity demoEntity = null;
 
     public AbstractStackedBaseSpawner(SpawnerBlockEntity spawnerBlockEntity, StackedSpawner stackedSpawner) {
@@ -122,11 +124,14 @@ public abstract class AbstractStackedBaseSpawner extends BaseSpawner {
             return;
         }
 
-        if (this.spawnDelay <= -tickDelay)
+        int consumedTickDelay = getModifiedTickDelay(serverLevel, blockPos, tickDelay, stackedSpawner);
+
+        if (this.spawnDelay <= -consumedTickDelay)
             resetSpawnDelay(serverLevel, blockPos);
 
         if (this.spawnDelay > 0) {
-            this.spawnDelay -= tickDelay;
+            if (consumedTickDelay > 0)
+                this.spawnDelay -= consumedTickDelay;
             return;
         }
 
@@ -313,6 +318,32 @@ public abstract class AbstractStackedBaseSpawner extends BaseSpawner {
     }
 
     protected abstract int getConfigTickDelay(ServerLevel serverLevel);
+
+    private int getModifiedTickDelay(ServerLevel serverLevel, BlockPos blockPos, int baseTickDelay, WStackedSpawner stackedSpawner) {
+        if (baseTickDelay <= 0)
+            return baseTickDelay;
+
+        Location location = new Location(serverLevel.getWorld(), blockPos.getX(), blockPos.getY(), blockPos.getZ());
+        SpawnerRateContext context = new SpawnerRateContext(
+                stackedSpawner,
+                location,
+                stackedSpawner.getSpawnedType(),
+                stackedSpawner.getStackAmount(),
+                baseTickDelay,
+                this.spawnDelay
+        );
+
+        double multiplier = plugin.getSystemManager().getSpawnerRateMultiplier(context);
+        if (Double.isNaN(multiplier) || Double.isInfinite(multiplier))
+            multiplier = 1.0D;
+
+        multiplier = Math.max(0.0D, multiplier);
+        double modifiedTickDelay = baseTickDelay * multiplier + this.spawnerRateRemainder;
+        int consumedTickDelay = (int) modifiedTickDelay;
+        this.spawnerRateRemainder = modifiedTickDelay - consumedTickDelay;
+
+        return consumedTickDelay;
+    }
 
     protected abstract Pair<Optional<EntityType<?>>, CompoundTag> getEntityDataFromSpawnData(ServerLevel serverLevel, SpawnData spawnData);
 

--- a/src/main/java/com/bgsoftware/wildstacker/handlers/SystemHandler.java
+++ b/src/main/java/com/bgsoftware/wildstacker/handlers/SystemHandler.java
@@ -18,6 +18,8 @@ import com.bgsoftware.wildstacker.api.objects.StackedSpawner;
 import com.bgsoftware.wildstacker.api.objects.UnloadedStackedBarrel;
 import com.bgsoftware.wildstacker.api.objects.UnloadedStackedSpawner;
 import com.bgsoftware.wildstacker.api.spawning.SpawnCondition;
+import com.bgsoftware.wildstacker.api.spawning.SpawnerRateContext;
+import com.bgsoftware.wildstacker.api.spawning.SpawnerRateModifier;
 import com.bgsoftware.wildstacker.database.DBSession;
 import com.bgsoftware.wildstacker.hooks.DataSerializer_Default;
 import com.bgsoftware.wildstacker.hooks.IDataSerializer;
@@ -88,6 +90,7 @@ public final class SystemHandler implements SystemManager {
 
     private final FastEnumMap<EntityType, Set<SpawnCondition>> spawnConditions = new FastEnumMap<>(EntityType.class);
     private final Map<String, SpawnCondition> spawnConditionsIds = new HashMap<>();
+    private final Map<String, SpawnerRateModifier> spawnerRateModifiers = new HashMap<>();
     private boolean loadedData = false;
 
     private IDataSerializer dataSerializer;
@@ -675,6 +678,42 @@ public final class SystemHandler implements SystemManager {
     public SpawnCondition registerSpawnCondition(SpawnCondition spawnCondition) {
         spawnConditionsIds.put(spawnCondition.getId().toLowerCase(), spawnCondition);
         return spawnCondition;
+    }
+
+    @Override
+    public SpawnerRateModifier registerSpawnerRateModifier(SpawnerRateModifier modifier) {
+        Preconditions.checkNotNull(modifier, "modifier parameter cannot be null.");
+        spawnerRateModifiers.put(modifier.getId().toLowerCase(), modifier);
+        return modifier;
+    }
+
+    @Override
+    public void unregisterSpawnerRateModifier(String id) {
+        if (id != null)
+            spawnerRateModifiers.remove(id.toLowerCase());
+    }
+
+    @Override
+    public double getSpawnerRateMultiplier(SpawnerRateContext context) {
+        double multiplier = 1.0D;
+
+        for (SpawnerRateModifier modifier : spawnerRateModifiers.values()) {
+            double modifierMultiplier;
+            try {
+                modifierMultiplier = modifier.getMultiplier(context);
+            } catch (Throwable error) {
+                WildStackerPlugin.log("An error occurred while calculating spawner-rate modifier " + modifier.getId() + ":");
+                error.printStackTrace();
+                continue;
+            }
+
+            if (Double.isNaN(modifierMultiplier) || Double.isInfinite(modifierMultiplier))
+                continue;
+
+            multiplier *= Math.max(0.0D, modifierMultiplier);
+        }
+
+        return multiplier;
     }
 
     public boolean isBarrelBlock(Material blockType, World world) {


### PR DESCRIPTION
Hello, i wanted to add a boost of spawner speed from another plugin so i guess the best method is to add RateMultiplier to the API and with that i'm able to edit it. ( I enabled the WS override so i can't do that without implement something into WS )