### PR TITLE
Fix runtime exceptions, inverted conditionals, permissions leakage, and concurrency issues

### DIFF
--- a/Hooks/MinableSpawners/src/main/java/com/bgsoftware/wildstacker/hooks/SpawnersProvider_MineableSpawners.java
+++ b/Hooks/MinableSpawners/src/main/java/com/bgsoftware/wildstacker/hooks/SpawnersProvider_MineableSpawners.java
@@ -151,7 +151,7 @@ public final class SpawnersProvider_MineableSpawners implements SpawnersProvider
             }
 
             if (mineableSpawners.getEcon() != null && mineableSpawners.getConfigurationHandler().getBoolean("mining", "charge")) {
-                double cost = !allSamePrice ? globalPrice : prices.getOrDefault(entityType, globalPrice);
+                double cost = allSamePrice ? globalPrice : prices.getOrDefault(entityType, globalPrice);
 
                 if (!mineableSpawners.getEcon().withdrawPlayer(player, cost).transactionSuccess())
                     return;

--- a/src/main/java/com/bgsoftware/wildstacker/command/CommandsHandler.java
+++ b/src/main/java/com/bgsoftware/wildstacker/command/CommandsHandler.java
@@ -66,7 +66,7 @@ public final class CommandsHandler implements CommandExecutor, TabCompleter {
                 Locale.HELP_COMMAND_HEADER.send(sender);
 
                 for (ICommand cmd : subCommands) {
-                    if (sender.hasPermission(subCommand.getPermission()))
+                    if (cmd.getPermission() == null || sender.hasPermission(cmd.getPermission()))
                         Locale.HELP_COMMAND_LINE.send(sender, cmd.getUsage(), cmd.getDescription());
                 }
 

--- a/src/main/java/com/bgsoftware/wildstacker/command/commands/CommandKill.java
+++ b/src/main/java/com/bgsoftware/wildstacker/command/commands/CommandKill.java
@@ -185,7 +185,7 @@ public final class CommandKill implements ICommand {
 
             return Math.abs(player.getBlockX() - entity.getBlockX()) <= radius &&
                     Math.abs(player.getBlockY() - entity.getBlockY()) <= radius &&
-                    Math.abs(player.getBlockY() - entity.getBlockY()) <= radius;
+                    Math.abs(player.getBlockZ() - entity.getBlockZ()) <= radius;
         }
 
         private boolean hasEntityType(EntityTypes entityType) {

--- a/src/main/java/com/bgsoftware/wildstacker/data/AbstractBlockDataStore.java
+++ b/src/main/java/com/bgsoftware/wildstacker/data/AbstractBlockDataStore.java
@@ -104,8 +104,13 @@ public abstract class AbstractBlockDataStore<T extends StackedObject<?>, U exten
     public void storeUnloaded(U unloaded) {
         String worldName = unloaded.getWorldName();
         long packedPos = ChunkPosition.getPackedPos(unloaded.getX() >> 4, unloaded.getZ() >> 4);
-        this.unloadedStore.computeIfAbsent(worldName, packedPos, LinkedHashSet::new).add(unloaded);
-        ++this.unloadedStoreSize;
+        try {
+            this.unloadedStoreLock.writeLock().lock();
+            this.unloadedStore.computeIfAbsent(worldName, packedPos, LinkedHashSet::new).add(unloaded);
+            ++this.unloadedStoreSize;
+        } finally {
+            this.unloadedStoreLock.writeLock().unlock();
+        }
     }
 
 

--- a/src/main/java/com/bgsoftware/wildstacker/handlers/DataHandler.java
+++ b/src/main/java/com/bgsoftware/wildstacker/handlers/DataHandler.java
@@ -273,7 +273,7 @@ public final class DataHandler {
                     this.stackedSpawnerStore.storeUnloaded(unloadedStackedSpawner);
                     continue;
                 } catch (Exception ex) {
-                    exceptionReason = "Exception was thrown.";
+                    exceptionReason = ex.getMessage() == null ? ex.toString() : ex.getMessage();
                 }
 
                 WildStackerPlugin.log("Couldn't load spawner: " + location);
@@ -325,7 +325,7 @@ public final class DataHandler {
                     this.stackedBarrelStore.storeUnloaded(unloadedStackedBarrel);
                     continue;
                 } catch (Exception ex) {
-                    exceptionReason = "Exception was thrown.";
+                    exceptionReason = ex.getMessage() == null ? ex.toString() : ex.getMessage();
                 }
 
                 WildStackerPlugin.log("Couldn't load barrel: " + location);

--- a/src/main/java/com/bgsoftware/wildstacker/listeners/EntitiesListener.java
+++ b/src/main/java/com/bgsoftware/wildstacker/listeners/EntitiesListener.java
@@ -679,7 +679,7 @@ public final class EntitiesListener implements Listener {
         if (!nearbyEntitiesAmounts.isEmpty()) {
             Executor.sync(() -> {
                 for (Entity entity : event.getWorld().getNearbyEntities(event.getLightning().getLocation(), 2, 2, 2)) {
-                    if (entity instanceof PigZombie) {
+                    if (entity instanceof PigZombie && !nearbyEntitiesAmounts.isEmpty()) {
                         this.handleEntityTransform(entity, "LIGHTNING", nearbyEntitiesAmounts.remove(0), SpawnCause.LIGHTNING);
                     }
                 }

--- a/src/main/java/com/bgsoftware/wildstacker/utils/entity/logic/DeathSimulation.java
+++ b/src/main/java/com/bgsoftware/wildstacker/utils/entity/logic/DeathSimulation.java
@@ -377,7 +377,8 @@ public final class DeathSimulation {
         } catch (IllegalArgumentException ignored) {
         }
 
-        plugin.getNMSEntities().awardKillScore(sourceKiller, stackedEntity.getLivingEntity(), directKiller);
+        if (directKiller != null)
+            plugin.getNMSEntities().awardKillScore(sourceKiller, stackedEntity.getLivingEntity(), directKiller);
     }
 
     private static void reduceKillerToolDurability(ItemStack damagerTool, Player killer) {


### PR DESCRIPTION
Fixed several critical issues across the codebase, including a NullPointerException during death simulation when mobs die of environmental damage, an IndexOutOfBoundsException on lightning strikes, an inverted cost conditional in the MineableSpawners hook, missing Z-axis bounds checks in the kill command filter, permission leak in help command generation, broken invalid-world database cleanup due to hardcoded exception messages, and unsynchronized access in `AbstractBlockDataStore#storeUnloaded`.